### PR TITLE
Fixed bug where info panel flyout was not displayed in Minimal theme

### DIFF
--- a/src/ui/panels/debugsection.tsx
+++ b/src/ui/panels/debugsection.tsx
@@ -1,7 +1,7 @@
 import "./debugsection.css"
 import Flyout from "../flyout"
 import { faInfo as faHelp, faInfoCircle, faBug, faTerminal } from "@fortawesome/free-solid-svg-icons"
-import { handleGetIsDebugging, handleGetShowDebugTab, passSetDebug, passSetShowDebugTab } from "../main2worker"
+import { handleGetShowDebugTab, passSetDebug, passSetShowDebugTab } from "../main2worker"
 import { crc32, UI_THEME } from "../../common/utility"
 import { getHelpText, getTheme } from "../ui_settings"
 import { useMemo, useState } from "react"
@@ -29,11 +29,15 @@ const DebugSection = (props: { updateDisplay: UpdateDisplay }) => {
   const newHelpTextCrc = crc32(new TextEncoder().encode(helpText))
   const showHighlight = !isFlyoutOpen && newHelpTextCrc != helpTextCrc && newHelpTextCrc != defaultHelpTextCrc
 
+  const forceRefresh = () => {
+    // Force a refresh to pick up the new canvas size
+    setTimeout(() => { window.dispatchEvent(new Event("resize")) }, 100)
+  }
+  
   const handleTabClick = (tabIndex: number) => (event: React.MouseEvent<HTMLElement>) => {
     setActiveTab(tabIndex)
     event.stopPropagation()
-    // Force a refresh to pick up the new canvas size
-    setTimeout(() => { window.dispatchEvent(new Event("resize")) }, 20)
+    forceRefresh()
     if (tabIndex == 1) {
       passSetDebug(true)
     }
@@ -43,11 +47,13 @@ const DebugSection = (props: { updateDisplay: UpdateDisplay }) => {
   const isSmall = isMinimalTheme && window.innerWidth < 800
 
   if (handleGetShowDebugTab()) {
+    setIsFlyoutOpen(true)
     setActiveTab(1)
     passSetShowDebugTab(false)
   }
 
   useMemo(() => {
+    forceRefresh()
     setHelpTextCrc(newHelpTextCrc)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isFlyoutOpen])
@@ -58,7 +64,7 @@ const DebugSection = (props: { updateDisplay: UpdateDisplay }) => {
       position="top-right"
       title="debug panel"
       highlight={showHighlight}
-      isOpen={handleGetIsDebugging}
+      isOpen={() => { return isFlyoutOpen}}
       onClick={() => {
         setIsFlyoutOpen(!isFlyoutOpen)
         props.updateDisplay()

--- a/src/ui/panels/diskcollectionpanel.css
+++ b/src/ui/panels/diskcollectionpanel.css
@@ -248,6 +248,7 @@
 
 @media (min-width: 1290px) {
   .disk-collection-panel {
+    grid-template-rows: repeat(auto-fill, minmax(200px, 1fr));
     grid-template-columns: repeat(auto-fill, minmax(192px, 1fr));
   }
 

--- a/src/ui/tours/tourdebug.tsx
+++ b/src/ui/tours/tourdebug.tsx
@@ -1,5 +1,5 @@
 import { Step } from "react-joyride"
-import { handleGetRunMode, passSetDebug, passSetRunMode } from "../main2worker"
+import { handleGetRunMode, passSetDebug, passSetRunMode, passSetShowDebugTab } from "../main2worker"
 import { RUN_MODE } from "../../common/utility"
 
 let neededToBoot = false
@@ -10,6 +10,7 @@ const callbackInDebugMode: StepCallbackFunction = () => {
   neededToBoot = runMode === RUN_MODE.IDLE
   didBoot = false
   passSetDebug(true)
+  passSetShowDebugTab(true)
   // Continue processing tour commands
   return false
 }


### PR DESCRIPTION
- Updated info panel flyout to use `isFlyoutOpen` rather than `handleGetIsDebugging()` to show/hide panel
- Fixed bug where Debug tour was not correctly switching to the debugging tab in the Classic theme
- Some tours are still broken in Minimal theme due to an unrelated issue (will investigate separately)