### PR TITLE
Fix for theme switching bug

### DIFF
--- a/src/ui/controls/configbuttons.tsx
+++ b/src/ui/controls/configbuttons.tsx
@@ -108,6 +108,7 @@ const ConfigButtons = (props: DisplayProps) => {
                 setPreferenceTheme(i)
                 const url = new URL(window.location.href)
                 url.searchParams.delete("theme")
+                url.searchParams.set("cache", new Date().getTime().toString())
                 window.location.href = url.toString()
               }
             }


### PR DESCRIPTION
<img width="2496" height="1592" alt="image" src="https://github.com/user-attachments/assets/4de2f794-b48f-42d0-a309-41502397f85c" />
<img width="2496" height="1592" alt="image" src="https://github.com/user-attachments/assets/84319771-fb1d-4300-9a4b-22f03386ceb0" />
<img width="2496" height="1592" alt="image" src="https://github.com/user-attachments/assets/0e8fc473-a069-48ef-a672-64ba2f2b8c7e" />

**Changes made:**
- Added cache buster to theme switching code to force emulator to always reload

**Tests performed:**
- Verified switching between all themes with the following URL works as expected: https://localhost:6502/?color=white&speed=fast#https://a2desktop.s3.amazonaws.com/A2DeskTop-1.4-en_800k.2mg
- Verififed on multiple devices (Mac, PC, iPhone, iPad) and browsers (Chrome, Edge, Safari, Firefox)