### PR TITLE
Fixes #224 - Windows Alt key problems

### DIFF
--- a/src/ui/canvas.tsx
+++ b/src/ui/canvas.tsx
@@ -182,11 +182,16 @@ const Apple2Canvas = (props: DisplayProps) => {
 
   const handleKeyDown = (e: keyEvent) => {
     let keyHandledLocal = false
+    const isBrowserAltKey = e.code === "AltLeft" || e.code === "AltRight"
     if (isOpenAppleDown(e)) {
       passAppleCommandKeyPress(true)
     }
     if (isClosedAppleDown(e)) {
       passAppleCommandKeyPress(false)
+    }
+    if (isBrowserAltKey) {
+      e.preventDefault()
+      e.stopPropagation()
     }
     // TODO: What modifier key should be used on Windows? Can't use Ctrl
     // because that interferes with Apple II control keys like Ctrl+S
@@ -280,6 +285,7 @@ const Apple2Canvas = (props: DisplayProps) => {
   }
 
   const handleKeyUp = (e: keyEvent) => {
+    const isBrowserAltKey = e.code === "AltLeft" || e.code === "AltRight"
     if (isOpenAppleUp(e)) {
       passAppleCommandKeyRelease(true)
     } else if (isClosedAppleUp(e)) {
@@ -294,6 +300,11 @@ const Apple2Canvas = (props: DisplayProps) => {
       e.preventDefault()
       e.stopPropagation()
     }
+    if (isBrowserAltKey) {
+      e.preventDefault()
+      e.stopPropagation()
+      return
+    }
   }
 
   const checkContentHeight = () => {
@@ -306,6 +317,22 @@ const Apple2Canvas = (props: DisplayProps) => {
       document.body.classList.add("no-scroll")
     } else {
       document.body.classList.remove("no-scroll")
+    }
+  }
+
+  const releaseBlurredModifierState = () => {
+    passAppleCommandKeyRelease(true)
+    passAppleCommandKeyRelease(false)
+    passKeyRelease()
+  }
+
+  const handleWindowBlur = () => {
+    releaseBlurredModifierState()
+  }
+
+  const handleVisibilityChange = () => {
+    if (document.hidden) {
+      releaseBlurredModifierState()
     }
   }
 
@@ -548,6 +575,8 @@ const Apple2Canvas = (props: DisplayProps) => {
         const paste = (e: object) => { pasteHandler(e as ClipboardEvent) }
         canvas.addEventListener("paste", paste)
         window.addEventListener("resize", handleResize)
+        window.addEventListener("blur", handleWindowBlur)
+        document.addEventListener("visibilitychange", handleVisibilityChange)
         ensureGamepadEventListeners()
         handleResize()
 


### PR DESCRIPTION
Fixes Alt-Tab leaves button 0/1 down, and Alt key changes focus to browser menu in Chrome/Edge/Firefox on Windows.