### PR TITLE
Fix: Cloud drive auth

### DIFF
--- a/src/ui/devices/disk/googledrive.ts
+++ b/src/ui/devices/disk/googledrive.ts
@@ -11,16 +11,22 @@ let g_accessToken: string = ""
 let g_pickerInited = false
 
 export class GoogleDrive implements CloudProvider {
-  
+
+  // The token client can only be created after the Google Identity Services
+  // script has loaded, so it is created lazily in ensureScriptsLoaded() rather
+  // than in a class-field initializer (which would run before the script loads).
+  tokenClient: GoogleTokenClient | null = null
+
   async ensureScriptsLoaded() {
     await loadGoogleDriveScripts()
+    if (!this.tokenClient) {
+      this.tokenClient = google.accounts.oauth2.initTokenClient({
+        client_id: appID() + "-" + clientID() + ".apps.googleusercontent.com",
+        scope: "https://www.googleapis.com/auth/drive.file",
+        callback: () => {}, // defined later
+      })
+    }
   }
-
-  tokenClient: GoogleTokenClient = google.accounts.oauth2.initTokenClient({
-    client_id: appID() + "-" + clientID() + ".apps.googleusercontent.com",
-    scope: "https://www.googleapis.com/auth/drive.file",
-    callback: () => {}, // defined later
-  })
 
   private resolvePicker: ((result: GoogleDriveResult | null) => void) | null = null
 
@@ -64,7 +70,7 @@ export class GoogleDrive implements CloudProvider {
     }
 
     // Request an access token.
-    this.tokenClient.callback = async (response: google.accounts.oauth2.TokenResponse) => {
+    this.tokenClient!.callback = async (response: google.accounts.oauth2.TokenResponse) => {
       if (response.error !== undefined) {
         throw (response)
       }
@@ -75,7 +81,7 @@ export class GoogleDrive implements CloudProvider {
     if (g_accessToken === "") {
       // Prompt the user to select a Google Account and ask for consent to share their data
       // when establishing a new session.
-      this.tokenClient.requestAccessToken({prompt: "consent"})
+      this.tokenClient!.requestAccessToken({prompt: "consent"})
     } else {
       // Skip display of account chooser and consent dialog for an existing session.
       showPicker(view, filter)
@@ -117,14 +123,14 @@ export class GoogleDrive implements CloudProvider {
 
   requestAuthToken(callback: (authToken: string) => void) {
     this.ensureScriptsLoaded().then(() => {
-      this.tokenClient.callback = async (response: google.accounts.oauth2.TokenResponse) => {
+      this.tokenClient!.callback = async (response: google.accounts.oauth2.TokenResponse) => {
         if (response.error !== undefined) {
           throw (response)
         }
         g_accessToken = response.access_token
         callback(`Bearer ${response.access_token}`)
       }
-      this.tokenClient.requestAccessToken({prompt: "consent"})
+      this.tokenClient!.requestAccessToken({prompt: "consent"})
     })
   }
 

--- a/src/ui/devices/disk/onedriveclouddrive.ts
+++ b/src/ui/devices/disk/onedriveclouddrive.ts
@@ -22,7 +22,11 @@ export class OneDriveCloudDrive implements CloudProvider {
     const port = baseUrl.port != "" ? `:${baseUrl.port}` : ""
     const redirectUri = `${baseUrl.protocol}//${baseUrl.hostname}${port}?cloudProvider=OneDrive`
 
-    window.open(`${authUrl}${redirectUri}`, "_blank")
+    // The redirect URI must be percent-encoded, otherwise its own query string
+    // (?cloudProvider=OneDrive) is parsed as part of the login.live.com URL and
+    // is dropped from the redirect, so the popup returns to Apple2TS without the
+    // cloudProvider marker and the access token is never picked up.
+    window.open(`${authUrl}${encodeURIComponent(redirectUri)}`, "_blank")
     const interval = window.setInterval(async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const accessToken = (window as any).accessToken

--- a/src/ui/inputparams.ts
+++ b/src/ui/inputparams.ts
@@ -2,6 +2,7 @@ import { COLOR_MODE, RUN_MODE, UI_THEME } from "../common/utility"
 import { useGlobalContext } from "./globalcontext"
 import { passSpeedMode, passSetRamWorks, passPasteText, handleGetState6502, passSetShowDebugTab, passSetMachineName, passSetBinaryBlock, handleGetSpeedMode, passSetAppMode, passSetRunMode, passSetDebug } from "./main2worker"
 import { setDefaultBinaryAddress, handleSetDiskFromURL } from "./devices/disk/driveprops"
+import { loadOneDriveScript } from "./devices/disk/cloudscriptloader"
 import { audioEnable } from "./devices/audio/speaker"
 import { setAppMode, setColorMode, setTabView, setTheme, setUIStateBoolean } from "./ui_settings"
 import * as pako from "pako"
@@ -259,6 +260,20 @@ export const handleInputParams = (paramString = "") => {
 // https://apple2ts.com/?color=white&speed=fast#https://a2desktop.s3.amazonaws.com/A2DeskTop-1.4-en_800k.2mg
 // https://apple2ts.com/#https://archive.org/download/TotalReplay/Total%20Replay%20v5.0.1.hdv
 // https://apple2ts.com/#https://archive.org/download/wozaday_Davids_Midnight_Magic/00playable.woz
+
+// The OneDrive file-picker SDK routes its OAuth flow through this page. It first
+// navigates its popup to <ourpage>?oauth=<config>, and later back to
+// <ourpage>#access_token=...&state=... In both cases the onAuth() handler in
+// onedrive.js must run here: it reads these parameters, redirects the popup to
+// the Microsoft login page, and finally posts the token back to the opener.
+// This mirrors the SDK's own detection, which reads both the query and the hash.
+const isOneDriveAuthRedirect = () => {
+  const params = new URLSearchParams(window.location.search)
+  const hashParams = new URLSearchParams(window.location.hash.replace(/^#/, ""))
+  const has = (key: string) => params.has(key) || hashParams.has(key)
+  return has("oauth") || ((has("access_token") || has("error")) && has("state"))
+}
+
 export const handleFragment = async (updateDisplay: UpdateDisplay, hasBasicProgram: boolean) => {
   const fragment = window.location.hash
   // If you start npm locally with 'npm start --xyz=blahblah', then npm
@@ -270,12 +285,23 @@ export const handleFragment = async (updateDisplay: UpdateDisplay, hasBasicProgr
       window.location.href = window.location.pathname + "?" + process.env.npm_config_urlparam
     }
   }
+  // If this page was opened as a OneDrive file-picker auth popup, load
+  // onedrive.js so its onAuth() handler can run. The SDK routes its OAuth flow
+  // through this page (first ?oauth=<config>, then #access_token=...&state=...),
+  // and onAuth() redirects the popup to the Microsoft login page and posts the
+  // token back to the opener. Because the script is now lazy-loaded, without
+  // this the popup is stranded on the Apple2TS page.
+  if (window.opener && isOneDriveAuthRedirect()) {
+    await loadOneDriveScript()
+    return
+  }
+
   if (fragment.length >= 2) {
     const params = new URLSearchParams(window.location.search)
     const cloudProvider = params.get("cloudProvider")
     const regex: RegExp = /access_token=([^&]+)/
     const matches = regex.exec(window.location.hash)
-    
+
     if (cloudProvider && matches && matches.length > 0) {
       // Handle access token in fragment for cloud drive providers
       const opener = window.opener as OpenerWindow


### PR DESCRIPTION
# Screenshots:

<img width="1721" height="1411" alt="image" src="https://github.com/user-attachments/assets/25805f37-c8cd-4dc9-9880-86d97c04a32d" />
<img width="1720" height="1410" alt="image" src="https://github.com/user-attachments/assets/76654ebf-ac2a-48f9-900c-cd9155f0f604" />
<img width="1721" height="1409" alt="image" src="https://github.com/user-attachments/assets/c16afd91-3497-4de2-8846-a291cc64e343" />

# Issue:
OneDrive and Google Drive auth flows were broken, effectively breaking cloud drive support entirely

# Changes:
- Fixed GoogleDrive token initialization issue
- Fixed broken OneDrive login page redirect bug

# Tests:
- Verified OneDrive and CloudDrive load/save/update scenarios all work as expected
- Tested on Mac OS only (fix should not be platform- or OS-dependent)