### PR TITLE
fix: make isolated speaker clicks audible after silence (fixes Aztec footstep sounds)

### DIFF
--- a/public/worklet/oscillator.js
+++ b/public/worklet/oscillator.js
@@ -45,6 +45,9 @@ class Oscillator extends AudioWorkletProcessor {
       // of looping around thru the entire tick array.
       if (delta > this.offset) {
         this.currIndex = (this.playbackIndex + this.offset) % this.len
+        let i0 = Math.floor(this.currIndex) % this.len
+        this.tick[i0] = this.tick[i0] + this.value
+        this.value = -this.value
       } else {
         let newIndex = this.currIndex + delta
         let i0 = Math.floor(this.currIndex) % this.len


### PR DESCRIPTION
### Summary
This PR fixes an issue where isolated, sparse speaker clicks (such as footstep sound effects in *Aztec*) are completely silent or lost in the audio worklet.

### How to verify/reproduce
You can easily compare the sound behavior between the original site and the patched version using the game *Aztec*:

1. **Original behavior (Unpatched)**:
   Go to the live site at https://apple2ts.com, load and play *Aztec*, turn up your volume, and move the character around. You will notice that the protagonist's walking footsteps are completely silent.
2. **Patched behavior (This PR)**:
   Go to the patched live site at https://anomixer.github.io/apple2ts/, load and play *Aztec*, turn up your volume, and move the character around. You will clearly hear the classic click-click footstep sounds as the character walks!

### Cause
In `public/worklet/oscillator.js`, if the sample delta between two speaker accesses exceeds `this.offset` (1524 samples / ~34.5ms), the processor assumes the start of a new sound and aligns `this.currIndex` to the playhead to avoid latency and buffer fill overhead. 

However, during this alignment, the code did not write the transition to the buffer or flip the speaker state (`this.value`). As a result, any isolated click following more than 34.5ms of silence was completely discarded. This made games like *Aztec* (which play sparse footstep clicks spaced far apart) completely silent when walking.

### Solution
Modified the `if (delta > this.offset)` block to still write the step transition to the buffer at the new aligned index and toggle `this.value`. This ensures single-sample clicks are preserved and correctly audible even after periods of silence.
