### PR TITLE
Fix: Undead and other disks still fail to fetch for export

### DIFF
--- a/src/ui/devices/disk/driveprops.ts
+++ b/src/ui/devices/disk/driveprops.ts
@@ -246,13 +246,87 @@ export const handleSetDiskFromCloudData = async (
   }
 }
 
-const getCorsProxyCandidates = (url: string): string[] => {
+type ProxyCandidate = {
+  id: string,
+  url: string,
+}
+
+const PROXY_SCORE_STORAGE_PREFIX = "proxy-score:"
+const proxyScoreMemoryCache = new Map<string, Record<string, number>>()
+
+const getProxyTargetDomain = (url: string): string => {
+  try {
+    return new URL(url).hostname.toLowerCase()
+  } catch {
+    return ""
+  }
+}
+
+const getProxyScoreRecord = (domain: string): Record<string, number> => {
+  if (!domain) return {}
+
+  const cached = proxyScoreMemoryCache.get(domain)
+  if (cached) return cached
+
+  try {
+    const raw = sessionStorage.getItem(PROXY_SCORE_STORAGE_PREFIX + domain)
+    if (!raw) {
+      const empty = {}
+      proxyScoreMemoryCache.set(domain, empty)
+      return empty
+    }
+
+    const parsed = JSON.parse(raw) as Record<string, number>
+    proxyScoreMemoryCache.set(domain, parsed)
+    return parsed
+  } catch {
+    const empty = {}
+    proxyScoreMemoryCache.set(domain, empty)
+    return empty
+  }
+}
+
+const persistProxyScoreRecord = (domain: string, record: Record<string, number>) => {
+  if (!domain) return
+  proxyScoreMemoryCache.set(domain, record)
+  try {
+    sessionStorage.setItem(PROXY_SCORE_STORAGE_PREFIX + domain, JSON.stringify(record))
+  } catch {
+    // sessionStorage may be unavailable; keep in-memory score only.
+  }
+}
+
+const noteProxyScore = (domain: string, proxyId: string, success: boolean) => {
+  if (!domain || !proxyId) return
+  const record = { ...getProxyScoreRecord(domain) }
+  const current = record[proxyId] || 0
+  const updated = success ? Math.min(20, current + 3) : Math.max(-20, current - 1)
+  record[proxyId] = updated
+  persistProxyScoreRecord(domain, record)
+}
+
+const sortProxyCandidatesForDomain = (domain: string, candidates: ProxyCandidate[]): ProxyCandidate[] => {
+  const record = getProxyScoreRecord(domain)
+  return candidates
+    .map((candidate, index) => ({
+      candidate,
+      index,
+      score: record[candidate.id] || 0,
+    }))
+    .sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score
+      return a.index - b.index
+    })
+    .map(entry => entry.candidate)
+}
+
+const getCorsProxyCandidates = (url: string): ProxyCandidate[] => {
   const encodedUrl = encodeURIComponent(url)
   return [
-    "https://proxy.corsfix.com/?" + url,
-    "https://proxy.corsfix.com/?" + encodedUrl,
-    "https://proxy.corsfix.com/?url=" + encodedUrl,
-    "https://corsproxy.io/?" + encodedUrl,
+    { id: "corsfix-raw", url: "https://proxy.corsfix.com/?" + url },
+    { id: "corsfix-encoded", url: "https://proxy.corsfix.com/?" + encodedUrl },
+    { id: "corsfix-param", url: "https://proxy.corsfix.com/?url=" + encodedUrl },
+    { id: "corsproxy-encoded", url: "https://corsproxy.io/?" + encodedUrl },
   ]
 }
 
@@ -279,22 +353,27 @@ const shouldAttemptDirectFetch = (url: string): boolean => {
 
 const fetchWithCorsProxy = async (url: string) => {
   let lastResponse: Response | null = null
-  const candidates = getCorsProxyCandidates(url)
+  const domain = getProxyTargetDomain(url)
+  const candidates = sortProxyCandidatesForDomain(domain, getCorsProxyCandidates(url))
 
   for (let i = 0; i < candidates.length; i++) {
-    const proxyUrl = candidates[i]
+    const candidate = candidates[i]
+    const proxyUrl = candidate.url
     const proxyName = proxyUrl.includes("corsproxy.io") ? "corsproxy.io" : "corsfix"
     try {
       const response = await fetch(proxyUrl)
 
       if (response.ok) {
+        noteProxyScore(domain, candidate.id, true)
         logFetchDebug(`Proxy fetch succeeded via ${proxyName} (attempt ${i + 1}/${candidates.length})`)
         return response
       }
 
+      noteProxyScore(domain, candidate.id, false)
       logFetchDebug(`Proxy attempt failed (${response.status}) via ${proxyName} (attempt ${i + 1}/${candidates.length})`)
       lastResponse = response
     } catch (error) {
+      noteProxyScore(domain, candidate.id, false)
       logFetchDebug(`Proxy attempt errored via ${proxyName} (attempt ${i + 1}/${candidates.length})`, error)
     }
   }

--- a/src/ui/devices/disk/driveprops.ts
+++ b/src/ui/devices/disk/driveprops.ts
@@ -4,7 +4,7 @@ import * as fflate from "fflate"
 import { OneDriveCloudDrive } from "./onedriveclouddrive"
 import { GoogleDrive } from "./googledrive"
 import { isHardDriveImage, RUN_MODE, MAX_DRIVES, replaceSuffix, FILE_SUFFIXES_DISK } from "../../../common/utility"
-// import { iconKey, iconData, iconName } from "../../img/iconfunctions"
+import { iconKey, iconData, iconName } from "../../img/iconfunctions"
 import { passSetDriveNewData, passSetDriveProps, passSetBinaryBlock, passPasteText, handleGetRunMode, passSetRunMode } from "../../main2worker"
 import { DISK_COLLECTION_ITEM_TYPE } from "../../diskdialog/diskcollectionpanel"
 import { showGlobalProgressModal } from "../../ui_utilities"
@@ -246,29 +246,77 @@ export const handleSetDiskFromCloudData = async (
   }
 }
 
-const fetchWithCorsProxy = async (url: string) => {
-  try {
-    const response = await fetch("https://proxy.corsfix.com/?" + url,
-      { headers: {"x-corsfix-cache": "true"} })
-    return response
-  } catch {
-    return null
-  }
+const getCorsProxyCandidates = (url: string): string[] => {
+  const encodedUrl = encodeURIComponent(url)
+  return [
+    "https://proxy.corsfix.com/?" + url,
+    "https://proxy.corsfix.com/?" + encodedUrl,
+    "https://proxy.corsfix.com/?url=" + encodedUrl,
+    "https://corsproxy.io/?" + encodedUrl,
+  ]
 }
 
-// const fetchWithCT6502Proxy = async (url: string) => {
-//   // Ask CT6502 for why we need to use this favicon header
-//   const favicon: { [key: string]: string } = {}
-//   favicon[iconKey()] = iconData()
-//   try {
-//     const fullURL = iconName() + url
-//     const response = await fetch(fullURL, { headers: favicon })
-//     return response
-//   } catch (error) {
-//     console.error("CT6502 proxy fetch failed:", error)
-//     return null
-//   }
-// }
+const fetchWithCorsProxy = async (url: string) => {
+  let lastResponse: Response | null = null
+  const candidates = getCorsProxyCandidates(url)
+
+  for (let i = 0; i < candidates.length; i++) {
+    const proxyUrl = candidates[i]
+    const proxyName = proxyUrl.includes("corsproxy.io") ? "corsproxy.io" : "corsfix"
+    try {
+      const response = await fetch(proxyUrl)
+
+      if (response.ok) {
+        console.log(`✅ Proxy fetch succeeded via ${proxyName} (attempt ${i + 1}/${candidates.length})`)
+        return response
+      }
+
+      console.warn(`⚠️ Proxy attempt failed (${response.status}) via ${proxyName} (attempt ${i + 1}/${candidates.length})`)
+      lastResponse = response
+    } catch (error) {
+      console.warn(`⚠️ Proxy attempt errored via ${proxyName} (attempt ${i + 1}/${candidates.length})`, error)
+    }
+  }
+
+  return lastResponse
+}
+
+const fetchWithCT6502Proxy = async (url: string) => {
+  const headers: { [key: string]: string } = {}
+  headers[iconKey()] = iconData()
+
+  try {
+    const response = await fetch(iconName() + url)
+    if (response.ok) {
+      console.log("✅ Proxy fetch succeeded via CT6502 proxy")
+    } else {
+      console.warn(`⚠️ CT6502 proxy failed (${response.status})`)
+
+      const keyedResponse = await fetch(iconName() + url, { headers })
+      if (keyedResponse.ok) {
+        console.log("✅ Proxy fetch succeeded via CT6502 proxy (keyed)")
+      } else {
+        console.warn(`⚠️ CT6502 keyed proxy failed (${keyedResponse.status})`)
+      }
+      return keyedResponse
+    }
+    return response
+  } catch (error) {
+    console.warn("⚠️ CT6502 proxy errored, retrying keyed", error)
+    try {
+      const keyedResponse = await fetch(iconName() + url, { headers })
+      if (keyedResponse.ok) {
+        console.log("✅ Proxy fetch succeeded via CT6502 proxy (keyed)")
+      } else {
+        console.warn(`⚠️ CT6502 keyed proxy failed (${keyedResponse.status})`)
+      }
+      return keyedResponse
+    } catch (keyedError) {
+      console.warn("⚠️ CT6502 keyed proxy errored", keyedError)
+      return null
+    }
+  }
+}
 
 let timerId: NodeJS.Timeout|null = null
 
@@ -394,6 +442,12 @@ export const handleSetDiskFromURL = async (url: string,
   if (!response || !response.ok) {
     console.log("Direct fetch failed, trying CORS proxy")
     response = await fetchWithCorsProxy(url)
+  }
+
+  if (!response || !response.ok) {
+    console.log("CORS proxy failed, trying CT6502 proxy")
+    response = await fetchWithCT6502Proxy(url)
+
     if (!response || !response.ok) {
       console.error(`❌ All fetch methods failed for: ${url}`)
       if (!callback) {

--- a/src/ui/devices/disk/driveprops.ts
+++ b/src/ui/devices/disk/driveprops.ts
@@ -256,6 +256,27 @@ const getCorsProxyCandidates = (url: string): string[] => {
   ]
 }
 
+const FETCH_DEBUG_LOGS = false
+
+const logFetchDebug = (...args: unknown[]) => {
+  if (FETCH_DEBUG_LOGS) {
+    console.log(...args)
+  }
+}
+
+const shouldAttemptDirectFetch = (url: string): boolean => {
+  try {
+    const parsed = new URL(url)
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return true
+    }
+    return parsed.origin === window.location.origin
+  } catch {
+    // If URL parsing fails, keep prior behavior and try direct fetch.
+    return true
+  }
+}
+
 const fetchWithCorsProxy = async (url: string) => {
   let lastResponse: Response | null = null
   const candidates = getCorsProxyCandidates(url)
@@ -267,14 +288,14 @@ const fetchWithCorsProxy = async (url: string) => {
       const response = await fetch(proxyUrl)
 
       if (response.ok) {
-        console.log(`✅ Proxy fetch succeeded via ${proxyName} (attempt ${i + 1}/${candidates.length})`)
+        logFetchDebug(`Proxy fetch succeeded via ${proxyName} (attempt ${i + 1}/${candidates.length})`)
         return response
       }
 
-      console.warn(`⚠️ Proxy attempt failed (${response.status}) via ${proxyName} (attempt ${i + 1}/${candidates.length})`)
+      logFetchDebug(`Proxy attempt failed (${response.status}) via ${proxyName} (attempt ${i + 1}/${candidates.length})`)
       lastResponse = response
     } catch (error) {
-      console.warn(`⚠️ Proxy attempt errored via ${proxyName} (attempt ${i + 1}/${candidates.length})`, error)
+      logFetchDebug(`Proxy attempt errored via ${proxyName} (attempt ${i + 1}/${candidates.length})`, error)
     }
   }
 
@@ -288,31 +309,31 @@ const fetchWithCT6502Proxy = async (url: string) => {
   try {
     const response = await fetch(iconName() + url)
     if (response.ok) {
-      console.log("✅ Proxy fetch succeeded via CT6502 proxy")
+      logFetchDebug("CT6502 proxy fetch succeeded")
     } else {
-      console.warn(`⚠️ CT6502 proxy failed (${response.status})`)
+      logFetchDebug(`CT6502 proxy failed (${response.status})`)
 
       const keyedResponse = await fetch(iconName() + url, { headers })
       if (keyedResponse.ok) {
-        console.log("✅ Proxy fetch succeeded via CT6502 proxy (keyed)")
+        logFetchDebug("CT6502 keyed proxy fetch succeeded")
       } else {
-        console.warn(`⚠️ CT6502 keyed proxy failed (${keyedResponse.status})`)
+        logFetchDebug(`CT6502 keyed proxy failed (${keyedResponse.status})`)
       }
       return keyedResponse
     }
     return response
   } catch (error) {
-    console.warn("⚠️ CT6502 proxy errored, retrying keyed", error)
+    logFetchDebug("CT6502 proxy errored, retrying keyed", error)
     try {
       const keyedResponse = await fetch(iconName() + url, { headers })
       if (keyedResponse.ok) {
-        console.log("✅ Proxy fetch succeeded via CT6502 proxy (keyed)")
+        logFetchDebug("CT6502 keyed proxy fetch succeeded")
       } else {
-        console.warn(`⚠️ CT6502 keyed proxy failed (${keyedResponse.status})`)
+        logFetchDebug(`CT6502 keyed proxy failed (${keyedResponse.status})`)
       }
       return keyedResponse
     } catch (keyedError) {
-      console.warn("⚠️ CT6502 keyed proxy errored", keyedError)
+      logFetchDebug("CT6502 keyed proxy errored", keyedError)
       return null
     }
   }
@@ -424,28 +445,26 @@ export const handleSetDiskFromURL = async (url: string,
   // hosts). The disk VTOC check that drives these downloads is serialized one
   // request at a time, so this does not flood Internet Archive with parallel
   // requests (the cause of the earlier 429 throttling).
-  console.log(`🌐 Attempting direct fetch: ${url}`)
-  try {
-    response = await fetch(url)
-    if (response.ok) {
-      console.log(`✅ Direct fetch succeeded: ${url}`)
-    } else {
-      console.log(`❌ Direct fetch failed with status ${response.status}: ${url}`)
+  if (shouldAttemptDirectFetch(url)) {
+    try {
+      response = await fetch(url)
+      if (!response.ok) {
+        response = null
+      }
+    } catch {
+      // Expected for many cross-origin sources; fall through to proxy chain.
       response = null
     }
-  } catch (error) {
-    console.log(`❌ Direct fetch failed with error: ${error}`)
-    response = null
   }
 
   // If direct fetch failed, try CORS proxies
   if (!response || !response.ok) {
-    console.log("Direct fetch failed, trying CORS proxy")
+    logFetchDebug("Direct fetch failed, trying CORS proxies")
     response = await fetchWithCorsProxy(url)
   }
 
   if (!response || !response.ok) {
-    console.log("CORS proxy failed, trying CT6502 proxy")
+    logFetchDebug("CORS proxies failed, trying CT6502 proxy")
     response = await fetchWithCT6502Proxy(url)
 
     if (!response || !response.ok) {
@@ -485,9 +504,7 @@ export const handleSetDiskFromURL = async (url: string,
   }
 
   try {
-    console.log(`📥 Downloading response body (Content-Length: ${response.headers.get("content-length") || "unknown"})...`)
     const fileBuffer = await response.arrayBuffer()
-    console.log(`✅ Downloaded ${fileBuffer.byteLength} bytes`)
 
     // Try to get filename from Content-Disposition header first
     const contentDisposition = response.headers.get("content-disposition")
@@ -495,7 +512,6 @@ export const handleSetDiskFromURL = async (url: string,
       const filenameMatch = contentDisposition.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/)
       if (filenameMatch && filenameMatch[1]) {
         name = filenameMatch[1].replace(/['"]/g, "")
-        console.log(`📋 Filename from Content-Disposition: ${name}`)
       }
     }
 
@@ -516,7 +532,6 @@ export const handleSetDiskFromURL = async (url: string,
     }
 
     if (url.toLowerCase().endsWith(".zip")) {
-      console.log("📦 Unzipping file...")
       const unzipper = new fflate.Unzip()
       unzipper.register(fflate.UnzipInflate)
 
@@ -528,7 +543,6 @@ export const handleSetDiskFromURL = async (url: string,
             if (data.length > 1024) {
               name = file.name
               buffer = data
-              console.log(`📄 Extracted file: ${name} (${data.length} bytes)`)
               return
             }
           }
@@ -547,7 +561,6 @@ export const handleSetDiskFromURL = async (url: string,
         }
       }
       buffer = fileBuffer
-      console.log(`📄 File loaded: ${name} (${buffer.byteLength} bytes)`)
     }
 
     if (buffer) {
@@ -555,11 +568,9 @@ export const handleSetDiskFromURL = async (url: string,
         callback(buffer)
       } else {
         // If we are loading from a URL, reset all drives. Fixes issue#186
-        console.log(`💾 Setting disk data for drive ${index}...`)
         resetAllDiskDrives()
         
         handleSetDiskOrFileFromBuffer(index, buffer, name, cloudData || null, null)
-        console.log("✅ Disk loaded successfully")
       }
     } else {
       if (callback) {

--- a/src/ui/devices/disk/internetarchive_utils.ts
+++ b/src/ui/devices/disk/internetarchive_utils.ts
@@ -2,6 +2,16 @@ import { iconKey, iconData, iconName } from "../../img/iconfunctions"
 
 export const internetArchiveUrlProtocol = "a2ia://"
 
+const getCorsProxyCandidates = (url: string): string[] => {
+  const encodedUrl = encodeURIComponent(url)
+  return [
+    "https://proxy.corsfix.com/?" + url,
+    "https://proxy.corsfix.com/?" + encodedUrl,
+    "https://proxy.corsfix.com/?url=" + encodedUrl,
+    "https://corsproxy.io/?" + encodedUrl,
+  ]
+}
+
 const iaResolveCache = new Map<string, {
   resolvedUrl: string,
   fileSize: number,
@@ -66,19 +76,25 @@ export const getDiskImageUrlFromIdentifier = async (identifier: string): Promise
       // Direct fetch failed (likely CORS); fall back to the proxies below.
     }
 
-    try {
-      if (!newDiskImageUrl) {
-        const response = await fetch("https://proxy.corsfix.com/?" + detailsUrl,
-          { headers: { "x-corsfix-cache": "true" } })
-        await processDiskImageResponse(response)
+    if (!newDiskImageUrl) {
+      for (const proxyUrl of getCorsProxyCandidates(detailsUrl)) {
+        try {
+          const response = await fetch(proxyUrl)
+          await processDiskImageResponse(response)
+          if (newDiskImageUrl) break
+        } catch {
+          // Continue to next proxy candidate.
+        }
       }
+    }
 
-      if (!newDiskImageUrl) {
+    if (!newDiskImageUrl) {
+      try {
         const response = await fetch(iconName() + detailsUrl, { headers: favicon })
         await processDiskImageResponse(response)
+      } catch {
+        // We cache failure below to avoid repeated hammering when a provider is down.
       }
-    } catch {
-      // We cache failure below to avoid repeated hammering when a provider is down.
     }
 
     iaResolveCache.set(identifier, {

--- a/src/ui/devices/disk/internetarchive_utils.ts
+++ b/src/ui/devices/disk/internetarchive_utils.ts
@@ -2,13 +2,87 @@ import { iconKey, iconData, iconName } from "../../img/iconfunctions"
 
 export const internetArchiveUrlProtocol = "a2ia://"
 
-const getCorsProxyCandidates = (url: string): string[] => {
+type ProxyCandidate = {
+  id: string,
+  url: string,
+}
+
+const PROXY_SCORE_STORAGE_PREFIX = "proxy-score:"
+const proxyScoreMemoryCache = new Map<string, Record<string, number>>()
+
+const getProxyTargetDomain = (url: string): string => {
+  try {
+    return new URL(url).hostname.toLowerCase()
+  } catch {
+    return ""
+  }
+}
+
+const getProxyScoreRecord = (domain: string): Record<string, number> => {
+  if (!domain) return {}
+
+  const cached = proxyScoreMemoryCache.get(domain)
+  if (cached) return cached
+
+  try {
+    const raw = sessionStorage.getItem(PROXY_SCORE_STORAGE_PREFIX + domain)
+    if (!raw) {
+      const empty = {}
+      proxyScoreMemoryCache.set(domain, empty)
+      return empty
+    }
+
+    const parsed = JSON.parse(raw) as Record<string, number>
+    proxyScoreMemoryCache.set(domain, parsed)
+    return parsed
+  } catch {
+    const empty = {}
+    proxyScoreMemoryCache.set(domain, empty)
+    return empty
+  }
+}
+
+const persistProxyScoreRecord = (domain: string, record: Record<string, number>) => {
+  if (!domain) return
+  proxyScoreMemoryCache.set(domain, record)
+  try {
+    sessionStorage.setItem(PROXY_SCORE_STORAGE_PREFIX + domain, JSON.stringify(record))
+  } catch {
+    // sessionStorage may be unavailable; keep in-memory score only.
+  }
+}
+
+const noteProxyScore = (domain: string, proxyId: string, success: boolean) => {
+  if (!domain || !proxyId) return
+  const record = { ...getProxyScoreRecord(domain) }
+  const current = record[proxyId] || 0
+  const updated = success ? Math.min(20, current + 3) : Math.max(-20, current - 1)
+  record[proxyId] = updated
+  persistProxyScoreRecord(domain, record)
+}
+
+const sortProxyCandidatesForDomain = (domain: string, candidates: ProxyCandidate[]): ProxyCandidate[] => {
+  const record = getProxyScoreRecord(domain)
+  return candidates
+    .map((candidate, index) => ({
+      candidate,
+      index,
+      score: record[candidate.id] || 0,
+    }))
+    .sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score
+      return a.index - b.index
+    })
+    .map(entry => entry.candidate)
+}
+
+const getCorsProxyCandidates = (url: string): ProxyCandidate[] => {
   const encodedUrl = encodeURIComponent(url)
   return [
-    "https://proxy.corsfix.com/?" + url,
-    "https://proxy.corsfix.com/?" + encodedUrl,
-    "https://proxy.corsfix.com/?url=" + encodedUrl,
-    "https://corsproxy.io/?" + encodedUrl,
+    { id: "corsfix-raw", url: "https://proxy.corsfix.com/?" + url },
+    { id: "corsfix-encoded", url: "https://proxy.corsfix.com/?" + encodedUrl },
+    { id: "corsfix-param", url: "https://proxy.corsfix.com/?url=" + encodedUrl },
+    { id: "corsproxy-encoded", url: "https://corsproxy.io/?" + encodedUrl },
   ]
 }
 
@@ -77,12 +151,19 @@ export const getDiskImageUrlFromIdentifier = async (identifier: string): Promise
     }
 
     if (!newDiskImageUrl) {
-      for (const proxyUrl of getCorsProxyCandidates(detailsUrl)) {
+      const domain = getProxyTargetDomain(detailsUrl)
+      const proxyCandidates = sortProxyCandidatesForDomain(domain, getCorsProxyCandidates(detailsUrl))
+      for (const candidate of proxyCandidates) {
         try {
-          const response = await fetch(proxyUrl)
+          const response = await fetch(candidate.url)
           await processDiskImageResponse(response)
-          if (newDiskImageUrl) break
+          if (newDiskImageUrl) {
+            noteProxyScore(domain, candidate.id, true)
+            break
+          }
+          noteProxyScore(domain, candidate.id, response.ok)
         } catch {
+          noteProxyScore(domain, candidate.id, false)
           // Continue to next proxy candidate.
         }
       }

--- a/src/ui/diskdialog/diskcollectionpanel.tsx
+++ b/src/ui/diskdialog/diskcollectionpanel.tsx
@@ -50,21 +50,6 @@ const getKnownFileSizeForUrl = (diskUrl?: string): number | undefined => {
   return match?.fileSize && match.fileSize > 0 ? match.fileSize : undefined
 }
 
-const shouldLoadScreenshotInPanel = (imageUrl?: string): boolean => {
-  if (!imageUrl) return false
-  if (imageUrl.startsWith("data:")) return true
-
-  try {
-    const parsed = new URL(imageUrl, window.location.href)
-    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-      return true
-    }
-    return parsed.origin === window.location.origin
-  } catch {
-    return true
-  }
-}
-
 // Assigns a disk's VTOC type without downloading its bytes, when possible:
 //  - HDV images are hard-drive volumes that are always ProDOS, so their type is
 //    set directly by file extension (no download or decode needed).
@@ -912,9 +897,6 @@ const DiskCollectionPanel = (props: DiskCollectionPanelProps) => {
         {tabs[activeTab].disks.map((diskCollectionItem, index) => {
           const isExportTab = activeTab == TAB_INDEX_SELECT
           const isDisabledForExport = isExportTab && !isDiskExportable(diskCollectionItem)
-          const panelScreenshotSrc = shouldLoadScreenshotInPanel(diskCollectionItem.imageUrl)
-            ? diskCollectionItem.imageUrl
-            : undefined
 
           return (
             <div
@@ -948,7 +930,7 @@ const DiskCollectionPanel = (props: DiskCollectionPanelProps) => {
                 }}
                 onContextMenu={handleItemRightClick(diskCollectionItem)}
               >
-                {panelScreenshotSrc && <img className="dcp-item-image" src={panelScreenshotSrc} />}
+                <img className="dcp-item-image" src={diskCollectionItem.imageUrl} />
                 <div className="dcp-item-icon-top-right">
                   {activeTab == 2 && diskCollectionItem.bookmarkId &&
                     <div

--- a/src/ui/diskdialog/diskcollectionpanel.tsx
+++ b/src/ui/diskdialog/diskcollectionpanel.tsx
@@ -50,6 +50,21 @@ const getKnownFileSizeForUrl = (diskUrl?: string): number | undefined => {
   return match?.fileSize && match.fileSize > 0 ? match.fileSize : undefined
 }
 
+const shouldLoadScreenshotInPanel = (imageUrl?: string): boolean => {
+  if (!imageUrl) return false
+  if (imageUrl.startsWith("data:")) return true
+
+  try {
+    const parsed = new URL(imageUrl, window.location.href)
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return true
+    }
+    return parsed.origin === window.location.origin
+  } catch {
+    return true
+  }
+}
+
 // Assigns a disk's VTOC type without downloading its bytes, when possible:
 //  - HDV images are hard-drive volumes that are always ProDOS, so their type is
 //    set directly by file extension (no download or decode needed).
@@ -897,6 +912,9 @@ const DiskCollectionPanel = (props: DiskCollectionPanelProps) => {
         {tabs[activeTab].disks.map((diskCollectionItem, index) => {
           const isExportTab = activeTab == TAB_INDEX_SELECT
           const isDisabledForExport = isExportTab && !isDiskExportable(diskCollectionItem)
+          const panelScreenshotSrc = shouldLoadScreenshotInPanel(diskCollectionItem.imageUrl)
+            ? diskCollectionItem.imageUrl
+            : undefined
 
           return (
             <div
@@ -930,7 +948,7 @@ const DiskCollectionPanel = (props: DiskCollectionPanelProps) => {
                 }}
                 onContextMenu={handleItemRightClick(diskCollectionItem)}
               >
-                <img className="dcp-item-image" src={diskCollectionItem.imageUrl} />
+                {panelScreenshotSrc && <img className="dcp-item-image" src={panelScreenshotSrc} />}
                 <div className="dcp-item-icon-top-right">
                   {activeTab == 2 && diskCollectionItem.bookmarkId &&
                     <div

--- a/src/ui/diskdialog/screenshot_utils.ts
+++ b/src/ui/diskdialog/screenshot_utils.ts
@@ -2,6 +2,8 @@
  * Screenshot capture and conversion utilities for HDV export
  */
 
+import { iconData, iconKey, iconName } from "../img/iconfunctions"
+
 type Rgb = [number, number, number]
 
 const sampleBilinear = (imageData: ImageData, x: number, y: number): Rgb => {
@@ -383,14 +385,45 @@ const blobToDataUrl = (blob: Blob): Promise<string | null> => {
   })
 }
 
+const getCorsProxyCandidates = (url: string): string[] => {
+  const encodedUrl = encodeURIComponent(url)
+  return [
+    "https://proxy.corsfix.com/?" + url,
+    "https://proxy.corsfix.com/?" + encodedUrl,
+    "https://proxy.corsfix.com/?url=" + encodedUrl,
+    "https://corsproxy.io/?" + encodedUrl,
+  ]
+}
+
 // Fetches a screenshot through the CORS proxy (matching disk-download behavior) and returns
 // its bytes as a data URL that can be loaded into an <img> without cross-origin taint.
 const fetchScreenshotViaProxy = async (absoluteUrl: string): Promise<string | null> => {
+  for (const proxyUrl of getCorsProxyCandidates(absoluteUrl)) {
+    try {
+      const response = await fetch(proxyUrl)
+      if (!response.ok) continue
+      return await blobToDataUrl(await response.blob())
+    } catch {
+      // Continue to next proxy candidate.
+    }
+  }
+
+  const headers: { [key: string]: string } = {}
+  headers[iconKey()] = iconData()
+
   try {
-    const response = await fetch("https://proxy.corsfix.com/?" + absoluteUrl,
-      { headers: { "x-corsfix-cache": "true" } })
-    if (!response.ok) return null
-    return await blobToDataUrl(await response.blob())
+    const response = await fetch(iconName() + absoluteUrl)
+    if (response.ok) {
+      return await blobToDataUrl(await response.blob())
+    }
+  } catch {
+    // Fall through to keyed request.
+  }
+
+  try {
+    const keyedResponse = await fetch(iconName() + absoluteUrl, { headers })
+    if (!keyedResponse.ok) return null
+    return await blobToDataUrl(await keyedResponse.blob())
   } catch {
     return null
   }

--- a/src/ui/diskdialog/screenshot_utils.ts
+++ b/src/ui/diskdialog/screenshot_utils.ts
@@ -376,6 +376,26 @@ const loadImageElement = (src: string, useCors: boolean): Promise<HTMLImageEleme
   })
 }
 
+const tryLoadImageElement = async (src: string, useCors: boolean): Promise<HTMLImageElement | null> => {
+  try {
+    return await loadImageElement(src, useCors)
+  } catch {
+    return null
+  }
+}
+
+const isCrossOriginHttpUrl = (src: string): boolean => {
+  try {
+    const parsed = new URL(src, window.location.href)
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return false
+    }
+    return parsed.origin !== window.location.origin
+  } catch {
+    return false
+  }
+}
+
 const blobToDataUrl = (blob: Blob): Promise<string | null> => {
   return new Promise((resolve) => {
     const reader = new FileReader()
@@ -491,15 +511,22 @@ export const loadAndConvertImageToHires = async (
     let proxyDataUrl: string | null = null
     let decodedFromNetwork = false
 
-    // Attempt 1: the resolved source — a cached data URL on a hit, else the network URL.
-    img = await loadImageElement(url, true)
-    if (img) decodedFromNetwork = !cached
+    // Attempt 1: load locally cached data URLs directly. For cross-origin network URLs,
+    // skip direct image loading (which predictably emits browser CORS errors) and let
+    // the proxy path below handle the fetch.
+    const isDirectCrossOrigin = !cached && cacheKey && isCrossOriginHttpUrl(cacheKey)
+    if (!isDirectCrossOrigin) {
+      img = await tryLoadImageElement(url, true)
+      if (img) decodedFromNetwork = !cached
+    }
 
     // (a) Self-heal: a cached data URL failed to decode (stale/poisoned entry). Evict it so
     //     it can't permanently break the export, then retry from the network.
     if (!img && cached && cacheKey && url !== cacheKey) {
       removeCachedScreenshot(cacheKey)
-      img = await loadImageElement(cacheKey, true)
+      if (!isCrossOriginHttpUrl(cacheKey)) {
+        img = await tryLoadImageElement(cacheKey, true)
+      }
       if (img) decodedFromNetwork = true
     }
 
@@ -507,7 +534,7 @@ export const loadAndConvertImageToHires = async (
     //     CORS proxy exactly like disk downloads, then load the returned bytes locally.
     if (!img && cacheKey) {
       proxyDataUrl = await fetchScreenshotViaProxy(cacheKey)
-      if (proxyDataUrl) img = await loadImageElement(proxyDataUrl, false)
+      if (proxyDataUrl) img = await tryLoadImageElement(proxyDataUrl, false)
     }
 
     if (!img) return buildFallbackHires()


### PR DESCRIPTION
<img width="2400" height="1528" alt="image" src="https://github.com/user-attachments/assets/ec20ab39-9776-4928-a1cc-89c584b524f5" />
<img width="2400" height="1528" alt="image" src="https://github.com/user-attachments/assets/9cacde9c-e702-4fc8-98fd-23366c2f7668" />
<img width="2400" height="1528" alt="image" src="https://github.com/user-attachments/assets/fa484942-ee11-46d8-afd3-38d627905817" />

Changes:
- Added proxy retries to handle problematic disks
- Cleaned up excessive logging and wrapped in debug toggle
- Deferred image download until the export to speed up exportability check
- Added per-domain proxy scoring to minimize proxy retires