### PR TITLE
Fix: Export hangs when exporting cloud disk

### DIFF
--- a/src/ui/devices/disk/diskdrive.tsx
+++ b/src/ui/devices/disk/diskdrive.tsx
@@ -17,10 +17,11 @@ import { passSetDriveProps } from "../../main2worker"
 import { DISK_COLLECTION_ITEM_TYPE } from "../../diskdialog/diskpanel_utils"
 import InternetArchivePopup from "./internetarchivedialog"
 import { DiskBookmarks } from "./diskbookmarks"
-import { determineVtocType } from "../../../common/prodos_hdv"
 import { isFileSystemApiSupported } from "../../ui_utilities"
 
 export const DISK_DRIVE_LABELS = ["S7D1", "S7D2", "S6D1", "S6D2"]
+const BOOKMARK_VTOC_PAUSE_UNTIL_KEY = "diskcollection-vtoc-pause-until"
+const BOOKMARK_VTOC_SUPPRESS_WHILE_OPEN_KEY = "diskcollection-vtoc-suppress-while-open"
 
 export const getBlobFromDiskData = (diskData: Uint8Array, filename: string): Blob => {
   // Only WOZ requires a checksum. Other formats should be ready to download.
@@ -300,8 +301,9 @@ const DiskDrive = (props: DiskDriveProps) => {
                     lastUpdated: new Date(Date.now()),
                     diskUrl: dprops.cloudData.downloadUrl,
                     cloudData: dprops.cloudData,
-                    vtocType: determineVtocType(dprops.cloudData.fileName || filename, dprops.diskData)
                   })
+                  sessionStorage.setItem(BOOKMARK_VTOC_PAUSE_UNTIL_KEY, String(Date.now() + 1500))
+                  sessionStorage.setItem(BOOKMARK_VTOC_SUPPRESS_WHILE_OPEN_KEY, "1")
                 }
               }
             },
@@ -400,8 +402,9 @@ const DiskDrive = (props: DiskDriveProps) => {
                     screenshotUrl: getImageDataUrlFromCanvas(),
                     lastUpdated: new Date(dprops.cloudData.lastSyncTime),
                     cloudData: dprops.cloudData,
-                    vtocType: determineVtocType(dprops.cloudData.fileName || filename, dprops.diskData)
                   })
+                  sessionStorage.setItem(BOOKMARK_VTOC_PAUSE_UNTIL_KEY, String(Date.now() + 1500))
+                  sessionStorage.setItem(BOOKMARK_VTOC_SUPPRESS_WHILE_OPEN_KEY, "1")
                 }
               }
             },

--- a/src/ui/devices/disk/driveprops.ts
+++ b/src/ui/devices/disk/driveprops.ts
@@ -207,39 +207,62 @@ export const handleSetDiskFromCloudData = async (
   }
 
   if (cloudProvider) {
+    const authTimeoutMs = 15000
+    let authResolved = false
+    const authTimeoutId = window.setTimeout(() => {
+      if (authResolved) return
+      authResolved = true
+      if (!callback) {
+        showGlobalProgressModal(false)
+        alert("Cloud authorization timed out. Please allow the popup/login window and try again.")
+      } else {
+        callback(null)
+      }
+    }, authTimeoutMs)
+
     cloudProvider.requestAuthToken(async (authToken: string) => {
+      if (authResolved) return
+      authResolved = true
+      clearTimeout(authTimeoutId)
       if (!callback) {
         showGlobalProgressModal(true, "Downloading disk")
       }
 
-      const response = await fetch(cloudData.downloadUrl, {
-        headers: {
-          "Authorization": authToken,
-          "Content-Type": "application/octet"
-        },
-        redirect: "follow"
-      })
-        .finally(() => {
-          if (!callback) {
-            showGlobalProgressModal(false)
-          }
+      try {
+        const response = await fetch(cloudData.downloadUrl, {
+          headers: {
+            "Authorization": authToken,
+            "Content-Type": "application/octet"
+          },
+          redirect: "follow"
         })
 
-      if (response.ok) {
-        const blob = await response.blob()
-        const buffer = await new Response(blob).arrayBuffer()
+        if (response.ok) {
+          const blob = await response.blob()
+          const buffer = await new Response(blob).arrayBuffer()
 
-        if (callback) {
-          callback(buffer)
+          if (callback) {
+            callback(buffer)
+          } else {
+            cloudData.lastSyncTime = Date.now()
+            handleSetDiskOrFileFromBuffer(driveIndex, buffer, cloudData.fileName, cloudData, null)
+          }
         } else {
-          cloudData.lastSyncTime = Date.now()
-          handleSetDiskOrFileFromBuffer(driveIndex, buffer, cloudData.fileName, cloudData, null)
+          if (callback) {
+            callback(null)
+          } else {
+            alert("Unable to download cloud disk. Please re-authenticate and try again.")
+          }
         }
-      } else {
+      } catch {
         if (callback) {
           callback(null)
         } else {
-          // $TODO: Add error handling
+          alert("Unable to download cloud disk. Please re-authenticate and try again.")
+        }
+      } finally {
+        if (!callback) {
+          showGlobalProgressModal(false)
         }
       }
     })

--- a/src/ui/diskdialog/diskcollectionpanel.tsx
+++ b/src/ui/diskdialog/diskcollectionpanel.tsx
@@ -18,6 +18,8 @@ import { isMinimalTheme } from "../ui_settings"
 import { faCircle } from "@fortawesome/free-regular-svg-icons"
 import { getDiskImageUrlFromIdentifier } from "../devices/disk/internetarchive_utils"
 import { showGlobalProgressModal } from "../ui_utilities"
+import { OneDriveCloudDrive } from "../devices/disk/onedriveclouddrive"
+import { GoogleDrive } from "../devices/disk/googledrive"
 import { sortDisks, DISK_COLLECTION_ITEM_TYPE, TAB_INDEX, getDiskCollection, getExportFilename, isDiskExportable, getExportBadgeInfo, loadDisk, createHdv } from "./diskpanel_utils"
 import { DiskItemTitle } from "./diskitemtitle"
 import { DiskPanelVtoc } from "./diskpanel_vtoc"
@@ -47,6 +49,44 @@ const defaultSortModeByTab: Record<number, DiskCollectionSortMode> = {
 
 const getSortModeForTab = (tabIndex: number): DiskCollectionSortMode => {
   return getPreferenceDiskCollectionSort(tabIndex) || defaultSortModeByTab[tabIndex] || "name-asc"
+}
+
+const createCloudProviderForItem = (item: DiskCollectionItem): CloudProvider | null => {
+  const providerName = item.cloudData?.providerName
+  if (!providerName) return null
+  switch (providerName) {
+    case "GoogleDrive":
+      return new GoogleDrive()
+    case "OneDrive":
+      return new OneDriveCloudDrive()
+    default:
+      return null
+  }
+}
+
+const requestCloudAuthTokenWithTimeout = (provider: CloudProvider, timeoutMs = 15000): Promise<boolean> => {
+  return new Promise((resolve) => {
+    let settled = false
+    const timeoutId = window.setTimeout(() => {
+      if (settled) return
+      settled = true
+      resolve(false)
+    }, timeoutMs)
+
+    try {
+      provider.requestAuthToken(() => {
+        if (settled) return
+        settled = true
+        clearTimeout(timeoutId)
+        resolve(true)
+      })
+    } catch {
+      if (settled) return
+      settled = true
+      clearTimeout(timeoutId)
+      resolve(false)
+    }
+  })
 }
 
 type DiskCollectionPanelProps = DisplayProps & {
@@ -159,7 +199,18 @@ const DiskCollectionPanel = (props: DiskCollectionPanelProps) => {
     event.stopPropagation()
   }
 
-  const prepareSelectedItem = async (diskCollectionItem: DiskCollectionItem) => {
+  const prepareSelectedItem = async (diskCollectionItem: DiskCollectionItem): Promise<DiskCollectionItem | null> => {
+    if (diskCollectionItem.type == DISK_COLLECTION_ITEM_TYPE.CLOUD_DRIVE && diskCollectionItem.cloudData) {
+      const cloudProvider = createCloudProviderForItem(diskCollectionItem)
+      if (cloudProvider) {
+        const authReady = await requestCloudAuthTokenWithTimeout(cloudProvider)
+        if (!authReady) {
+          alert("Cloud authorization did not complete. Please allow the provider popup and try selecting the disk again.")
+          return null
+        }
+      }
+    }
+
     if (diskCollectionItem.cloudData && (!diskCollectionItem.cloudData.fileSize || diskCollectionItem.cloudData.fileSize <= 0)) {
       let fileSize = 0
 
@@ -196,7 +247,10 @@ const DiskCollectionPanel = (props: DiskCollectionPanelProps) => {
       return
     }
 
-    await prepareSelectedItem(diskCollectionItem)
+    const preparedItem = await prepareSelectedItem(diskCollectionItem)
+    if (!preparedItem) {
+      return
+    }
     setSelectedDisks((prevSelectedDisks) => {
       if (prevSelectedDisks.includes(diskCollectionItem)) {
         return prevSelectedDisks
@@ -564,7 +618,8 @@ const DiskCollectionPanel = (props: DiskCollectionPanelProps) => {
               const newSelectedDisks = [...selectedDisks]
               for (const diskCollectionItem of tabs[TAB_INDEX.EXPORT].disks) {
                 if (isDiskExportable(diskCollectionItem) && !newSelectedDisks.includes(diskCollectionItem)) {
-                  await prepareSelectedItem(diskCollectionItem)
+                  const preparedItem = await prepareSelectedItem(diskCollectionItem)
+                  if (!preparedItem) continue
                   newSelectedDisks.push(diskCollectionItem)
                 }
               }

--- a/src/ui/diskdialog/diskcollectionpanel.tsx
+++ b/src/ui/diskdialog/diskcollectionpanel.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useEffect, useState } from "react"
+import { ChangeEvent, useEffect, useRef, useState } from "react"
 import "./diskcollectionpanel.css"
 import Flyout from "../flyout"
 import { faCommentDots, faCheckCircle, faClock, faCloud, faDownload, faFloppyDisk, faHardDrive, faStar } from "@fortawesome/free-solid-svg-icons"
@@ -15,7 +15,7 @@ import {
   setPreferenceNewReleasesChecked,
 } from "../localstorage"
 import { isMinimalTheme } from "../ui_settings"
-import { faCircle } from "@fortawesome/free-regular-svg-icons"
+import { faCircle, faStar as faStarOutline } from "@fortawesome/free-regular-svg-icons"
 import { getDiskImageUrlFromIdentifier } from "../devices/disk/internetarchive_utils"
 import { showGlobalProgressModal } from "../ui_utilities"
 import { OneDriveCloudDrive } from "../devices/disk/onedriveclouddrive"
@@ -111,6 +111,12 @@ const DiskCollectionPanel = (props: DiskCollectionPanelProps) => {
   const [selectedDisks, setSelectedDisks] = useState<DiskCollectionItem[]>([])
   const [exportQueue, setExportQueue] = useState<DiskCollectionItem[]>([])
   const [downloadedDisks, setDownloadedDisks] = useState<DownloadedExportDisk[]>([])
+  const [pendingBookmarkRemovals, setPendingBookmarkRemovals] = useState<Set<string>>(new Set())
+  const pendingBookmarkRemovalsRef = useRef<Set<string>>(new Set())
+
+  useEffect(() => {
+    pendingBookmarkRemovalsRef.current = pendingBookmarkRemovals
+  }, [pendingBookmarkRemovals])
 
 
 
@@ -191,9 +197,17 @@ const DiskCollectionPanel = (props: DiskCollectionPanelProps) => {
   }
 
   const handleBookmarkClick = (diskCollectionItem: DiskCollectionItem) => (event: React.MouseEvent<HTMLElement>) => {
-    if (diskCollectionItem.bookmarkId) {
-      diskBookmarks.remove(diskCollectionItem.bookmarkId)
-      setDiskBookmarks(new DiskBookmarks())
+    const bookmarkId = diskCollectionItem.bookmarkId
+    if (bookmarkId) {
+      setPendingBookmarkRemovals((prev) => {
+        const next = new Set(prev)
+        if (next.has(bookmarkId)) {
+          next.delete(bookmarkId)
+        } else {
+          next.add(bookmarkId)
+        }
+        return next
+      })
     }
 
     event.stopPropagation()
@@ -296,8 +310,7 @@ const DiskCollectionPanel = (props: DiskCollectionPanelProps) => {
       setActiveTab(0)
       // Dismiss the disk collection dialog/flyout so the error isn't left
       // hanging over a half-finished export.
-      props.onDismissDialog?.()
-      setIsFlyoutOpen(false)
+      dismissDiskCollection()
       alert("An unexpected error occurred while downloading the disk. Export to HDV has been aborted.")
     } else if (buffer !== undefined) {
       const currentItem = exportQueue[0]
@@ -341,9 +354,41 @@ const DiskCollectionPanel = (props: DiskCollectionPanelProps) => {
     return hdvSize <= 0 || hdvSize > maxHdvBytes
   }
 
+  const commitPendingBookmarkRemovals = (refreshBookmarks: boolean = true) => {
+    const pending = pendingBookmarkRemovalsRef.current
+    if (pending.size > 0) {
+      const bookmarks = new DiskBookmarks()
+      pending.forEach((bookmarkId) => {
+        bookmarks.remove(bookmarkId)
+      })
+    }
+
+    if (refreshBookmarks) {
+      setPendingBookmarkRemovals(new Set())
+      setDiskBookmarks(new DiskBookmarks())
+    }
+  }
+
+  const dismissDiskCollection = (notifyParent: boolean = true) => {
+    commitPendingBookmarkRemovals()
+    setIsFlyoutOpen(false)
+    if (notifyParent) {
+      props.onDismissDialog?.()
+    }
+  }
+
   useEffect(() => {
+    if (!isFlyoutOpen) return
+    setPendingBookmarkRemovals(new Set())
     setDiskBookmarks(new DiskBookmarks())
   }, [isFlyoutOpen])
+
+  useEffect(() => {
+    return () => {
+      commitPendingBookmarkRemovals(false)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   useEffect(() => {
     const newDiskCollectionFinal = getDiskCollection(diskBookmarks, newReleases)
@@ -363,8 +408,7 @@ const DiskCollectionPanel = (props: DiskCollectionPanelProps) => {
       setDownloadedDisks([])
       setSelectedDisks([])
       setActiveTab(0)
-      setIsFlyoutOpen(false)
-      props.onDismissDialog?.()
+      dismissDiskCollection()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [exportQueue])
@@ -375,7 +419,13 @@ const DiskCollectionPanel = (props: DiskCollectionPanelProps) => {
       buttonId="tour-disk-images"
       title="disk collection"
       isOpen={() => { return isFlyoutOpen }}
-      onClick={() => { setIsFlyoutOpen(!isFlyoutOpen) }}
+      onClick={() => {
+        if (isFlyoutOpen) {
+          dismissDiskCollection(false)
+        } else {
+          setIsFlyoutOpen(true)
+        }
+      }}
       width={`max( ${isMinimalTheme() ? "55vw" : "75vw"}, 348px )`}
       highlight={hasNewRelease}
       position="bottom-right">
@@ -396,6 +446,7 @@ const DiskCollectionPanel = (props: DiskCollectionPanelProps) => {
         {tabs[activeTab].disks.map((diskCollectionItem, index) => {
           const isExportTab = activeTab == TAB_INDEX.EXPORT
           const isDisabledForExport = isExportTab && !isDiskExportable(diskCollectionItem)
+          const isBookmarkPendingRemoval = !!diskCollectionItem.bookmarkId && pendingBookmarkRemovals.has(diskCollectionItem.bookmarkId)
 
           return (
             <div
@@ -435,9 +486,11 @@ const DiskCollectionPanel = (props: DiskCollectionPanelProps) => {
                   {activeTab == 2 && diskCollectionItem.bookmarkId &&
                     <div
                       className="dcp-item-bookmark"
-                      title="Click to remove from disk collection"
+                      title={isBookmarkPendingRemoval
+                        ? "Click to keep in disk collection"
+                        : "Click to mark for removal from disk collection"}
                       onClick={handleBookmarkClick(diskCollectionItem)}>
-                      <FontAwesomeIcon icon={faStar} size="lg" className="dcp-item-bookmark-icon" />
+                      <FontAwesomeIcon icon={isBookmarkPendingRemoval ? faStarOutline : faStar} size="lg" className="dcp-item-bookmark-icon" />
                     </div>}
                   {activeTab == TAB_INDEX.EXPORT && isDiskExportable(diskCollectionItem) &&
                     <div

--- a/src/ui/diskdialog/diskpanel_utils.ts
+++ b/src/ui/diskdialog/diskpanel_utils.ts
@@ -140,8 +140,12 @@ export const loadDisk = (
   diskCollectionItem: DiskCollectionItem | undefined,
   updateDisplay: UpdateDisplay,
   callback?: (buffer: ArrayBuffer | null) => void) => {
-  // We want to restart the emulator when loading a disk from our Disk Collection
-  passSetRunMode(RUN_MODE.IDLE)
+  // Only force idle when actually loading into a drive. Background fetches for
+  // export/VTOC pass a callback (and often driveIndex -1) and must not disrupt
+  // the currently running program/canvas state.
+  if (!callback && driveIndex >= 0) {
+    passSetRunMode(RUN_MODE.IDLE)
+  }
 
   if (diskCollectionItem) {
     if (diskCollectionItem.type == DISK_COLLECTION_ITEM_TYPE.CLOUD_DRIVE && diskCollectionItem.cloudData) {

--- a/src/ui/diskdialog/diskpanel_vtoc.tsx
+++ b/src/ui/diskdialog/diskpanel_vtoc.tsx
@@ -17,6 +17,9 @@ type DiskPanelVtocProps = {
   visibleCandidates: DiskCollectionItem[],
 }
 
+const BOOKMARK_VTOC_PAUSE_UNTIL_KEY = "diskcollection-vtoc-pause-until"
+const BOOKMARK_VTOC_SUPPRESS_WHILE_OPEN_KEY = "diskcollection-vtoc-suppress-while-open"
+
 // Downloads a disk's bytes without disturbing the running emulator. Unlike
 // loadDisk(), this never changes the run mode or loads the disk into a drive;
 // it simply resolves with the raw buffer (or null on failure) via callback.
@@ -100,11 +103,29 @@ export const DiskPanelVtoc = (props: DiskPanelVtocProps) => {
     // both themes, not just when isFlyoutOpen is toggled.
     const panelVisible = props.isFlyoutOpen || !isMinimalTheme()
     if (!panelVisible) {
+      sessionStorage.removeItem(BOOKMARK_VTOC_SUPPRESS_WHILE_OPEN_KEY)
       if (vtocProgressVisibleRef.current) {
         showGlobalProgressModal(false)
         vtocProgressVisibleRef.current = false
       }
       vtocActiveTabRef.current = null
+      return
+    }
+
+    if (sessionStorage.getItem(BOOKMARK_VTOC_SUPPRESS_WHILE_OPEN_KEY) === "1") {
+      if (vtocProgressVisibleRef.current) {
+        showGlobalProgressModal(false)
+        vtocProgressVisibleRef.current = false
+      }
+      return
+    }
+
+    const pauseUntil = Number(sessionStorage.getItem(BOOKMARK_VTOC_PAUSE_UNTIL_KEY) || 0)
+    if (Date.now() < pauseUntil) {
+      if (vtocProgressVisibleRef.current) {
+        showGlobalProgressModal(false)
+        vtocProgressVisibleRef.current = false
+      }
       return
     }
 


### PR DESCRIPTION
<img width="1200" height="764" alt="image" src="https://github.com/user-attachments/assets/a98e9616-1533-4c46-b679-08e47f6c97e5" />
<img width="2400" height="1528" alt="Screenshot 2026-07-05 145633" src="https://github.com/user-attachments/assets/b7b0cd3f-797f-41e7-b16f-d0acef3fae6f" />
<img width="2400" height="1528" alt="Screenshot 2026-07-05 151824" src="https://github.com/user-attachments/assets/cd2eca83-aade-4b28-883a-50869d5a46fd" />

Changes:
- Trigger cloud prompt when cloud disk is selected in export tab to avoid blocked popup during export
- Fixed bug where exporting while program was already running garbled the canvas
- Added bookmark toggle which deletes selected bookmarks when disk collection dialog is closed
- Fixed blocking pause when adding bookmark via disk menu by bypassing VTOC check