### PR TITLE
Fix: Cloud drive export auth issues

### DIFF
--- a/src/common/custom.d.ts
+++ b/src/common/custom.d.ts
@@ -158,7 +158,8 @@ type CloudProvider = {
   download(filter: string): Promise<[Blob, CloudData] | null>,
   upload(fileName: string, blob: Blob): Promise<CloudData | null>,
   sync(blob: Blob, cloudData: CloudData): Promise<boolean>,
-  requestAuthToken(callback: (authToken: string) => void): void
+  requestAuthToken(callback: (authToken: string) => void): void,
+  hasAuthToken(): boolean
 }
 
 // Custom writable file handle type that supports both browser FileSystemFileHandle

--- a/src/ui/devices/disk/diskdrive.tsx
+++ b/src/ui/devices/disk/diskdrive.tsx
@@ -21,6 +21,7 @@ import { isFileSystemApiSupported } from "../../ui_utilities"
 
 export const DISK_DRIVE_LABELS = ["S7D1", "S7D2", "S6D1", "S6D2"]
 const BOOKMARK_VTOC_PAUSE_UNTIL_KEY = "diskcollection-vtoc-pause-until"
+const BOOKMARK_VTOC_SUPPRESS_WHILE_OPEN_KEY = "diskcollection-vtoc-suppress-while-open"
 
 export const getBlobFromDiskData = (diskData: Uint8Array, filename: string): Blob => {
   // Only WOZ requires a checksum. Other formats should be ready to download.
@@ -302,6 +303,7 @@ const DiskDrive = (props: DiskDriveProps) => {
                     cloudData: dprops.cloudData,
                   })
                   sessionStorage.setItem(BOOKMARK_VTOC_PAUSE_UNTIL_KEY, String(Date.now() + 1500))
+                  sessionStorage.setItem(BOOKMARK_VTOC_SUPPRESS_WHILE_OPEN_KEY, "1")
                 }
               }
             },
@@ -402,6 +404,7 @@ const DiskDrive = (props: DiskDriveProps) => {
                     cloudData: dprops.cloudData,
                   })
                   sessionStorage.setItem(BOOKMARK_VTOC_PAUSE_UNTIL_KEY, String(Date.now() + 1500))
+                  sessionStorage.setItem(BOOKMARK_VTOC_SUPPRESS_WHILE_OPEN_KEY, "1")
                 }
               }
             },

--- a/src/ui/devices/disk/diskdrive.tsx
+++ b/src/ui/devices/disk/diskdrive.tsx
@@ -21,7 +21,6 @@ import { isFileSystemApiSupported } from "../../ui_utilities"
 
 export const DISK_DRIVE_LABELS = ["S7D1", "S7D2", "S6D1", "S6D2"]
 const BOOKMARK_VTOC_PAUSE_UNTIL_KEY = "diskcollection-vtoc-pause-until"
-const BOOKMARK_VTOC_SUPPRESS_WHILE_OPEN_KEY = "diskcollection-vtoc-suppress-while-open"
 
 export const getBlobFromDiskData = (diskData: Uint8Array, filename: string): Blob => {
   // Only WOZ requires a checksum. Other formats should be ready to download.
@@ -303,7 +302,6 @@ const DiskDrive = (props: DiskDriveProps) => {
                     cloudData: dprops.cloudData,
                   })
                   sessionStorage.setItem(BOOKMARK_VTOC_PAUSE_UNTIL_KEY, String(Date.now() + 1500))
-                  sessionStorage.setItem(BOOKMARK_VTOC_SUPPRESS_WHILE_OPEN_KEY, "1")
                 }
               }
             },
@@ -404,7 +402,6 @@ const DiskDrive = (props: DiskDriveProps) => {
                     cloudData: dprops.cloudData,
                   })
                   sessionStorage.setItem(BOOKMARK_VTOC_PAUSE_UNTIL_KEY, String(Date.now() + 1500))
-                  sessionStorage.setItem(BOOKMARK_VTOC_SUPPRESS_WHILE_OPEN_KEY, "1")
                 }
               }
             },

--- a/src/ui/devices/disk/diskdrive.tsx
+++ b/src/ui/devices/disk/diskdrive.tsx
@@ -17,11 +17,10 @@ import { passSetDriveProps } from "../../main2worker"
 import { DISK_COLLECTION_ITEM_TYPE } from "../../diskdialog/diskpanel_utils"
 import InternetArchivePopup from "./internetarchivedialog"
 import { DiskBookmarks } from "./diskbookmarks"
+import { determineVtocType } from "../../../common/prodos_hdv"
 import { isFileSystemApiSupported } from "../../ui_utilities"
 
 export const DISK_DRIVE_LABELS = ["S7D1", "S7D2", "S6D1", "S6D2"]
-const BOOKMARK_VTOC_PAUSE_UNTIL_KEY = "diskcollection-vtoc-pause-until"
-const BOOKMARK_VTOC_SUPPRESS_WHILE_OPEN_KEY = "diskcollection-vtoc-suppress-while-open"
 
 export const getBlobFromDiskData = (diskData: Uint8Array, filename: string): Blob => {
   // Only WOZ requires a checksum. Other formats should be ready to download.
@@ -301,9 +300,8 @@ const DiskDrive = (props: DiskDriveProps) => {
                     lastUpdated: new Date(Date.now()),
                     diskUrl: dprops.cloudData.downloadUrl,
                     cloudData: dprops.cloudData,
+                    vtocType: determineVtocType(dprops.cloudData.fileName || filename, dprops.diskData)
                   })
-                  sessionStorage.setItem(BOOKMARK_VTOC_PAUSE_UNTIL_KEY, String(Date.now() + 1500))
-                  sessionStorage.setItem(BOOKMARK_VTOC_SUPPRESS_WHILE_OPEN_KEY, "1")
                 }
               }
             },
@@ -402,9 +400,8 @@ const DiskDrive = (props: DiskDriveProps) => {
                     screenshotUrl: getImageDataUrlFromCanvas(),
                     lastUpdated: new Date(dprops.cloudData.lastSyncTime),
                     cloudData: dprops.cloudData,
+                    vtocType: determineVtocType(dprops.cloudData.fileName || filename, dprops.diskData)
                   })
-                  sessionStorage.setItem(BOOKMARK_VTOC_PAUSE_UNTIL_KEY, String(Date.now() + 1500))
-                  sessionStorage.setItem(BOOKMARK_VTOC_SUPPRESS_WHILE_OPEN_KEY, "1")
                 }
               }
             },

--- a/src/ui/devices/disk/googledrive.ts
+++ b/src/ui/devices/disk/googledrive.ts
@@ -123,8 +123,7 @@ export class GoogleDrive implements CloudProvider {
 
   requestAuthToken(callback: (authToken: string) => void) {
     this.ensureScriptsLoaded().then(() => {
-      if (!g_accessToken) {
-        this.tokenClient!.callback = async (response: google.accounts.oauth2.TokenResponse) => {
+      if (!g_accessToken) {        this.tokenClient!.callback = async (response: google.accounts.oauth2.TokenResponse) => {
           if (response.error !== undefined) {
             throw (response)
           }
@@ -136,6 +135,12 @@ export class GoogleDrive implements CloudProvider {
         callback(`Bearer ${g_accessToken}`)
       }
     })
+  }
+
+  // Whether a Google Drive access token is already cached in memory. Used to
+  // decide, without triggering an auth popup, whether a sign-in is still needed.
+  hasAuthToken(): boolean {
+    return g_accessToken !== ""
   }
 
   async download(filter: string): Promise<[Blob, CloudData]|null> {

--- a/src/ui/devices/disk/onedriveclouddrive.ts
+++ b/src/ui/devices/disk/onedriveclouddrive.ts
@@ -42,6 +42,12 @@ export class OneDriveCloudDrive implements CloudProvider {
     }
   }
 
+  // Whether a OneDrive access token is already cached in memory. Used to decide,
+  // without triggering an auth popup, whether a sign-in is still needed.
+  hasAuthToken(): boolean {
+    return !!g_accessToken
+  }
+
   async download(filter: string): Promise<[Blob, CloudData]|null> {
     await this.ensureScriptsLoaded()
     const result = await launchPicker("share", "files", filter)

--- a/src/ui/diskdialog/diskcollectionpanel.css
+++ b/src/ui/diskdialog/diskcollectionpanel.css
@@ -22,11 +22,56 @@
   display: flex;
   align-items: stretch;
   margin-left: -2px;
-  margin-right: -8px;
+  margin-right: 0;
   padding: 8px 12px 0px 12px;
   height: 52px;
   box-sizing: border-box;
   border-bottom: 1px solid black;
+}
+
+.dcp-auth-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-left: 0;
+  margin-right: 0;
+  height: 32px;
+  padding: 3px 14px;
+  box-sizing: border-box;
+  background-color: #fff3cd;
+  color: black;
+  border-bottom: 1px solid black;
+}
+
+.dcp-auth-bar-text {
+  font-size: 11pt;
+  line-height: 1.2;
+  font-weight: 700;
+  color: black;
+}
+
+.dcp-auth-bar-button {
+  appearance: none;
+  -webkit-appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10pt;
+  line-height: 1;
+  color: black;
+  height: 1.8em;
+  padding: 2px 10px;
+  white-space: nowrap;
+  border-radius: 8px;
+  border: 1px solid black;
+  background-color: white;
+  cursor: pointer;
+  padding-top: 4px;
+}
+
+.dcp-auth-bar-button:hover {
+  background-color: gray;
 }
 
 .dcp-tab {
@@ -135,7 +180,7 @@
   cursor: pointer;
 }
 
-.dcp-export-button:hover {
+.dcp-export-button:hover:not(:disabled) {
   background-color: gray;
 }
 

--- a/src/ui/diskdialog/diskcollectionpanel.tsx
+++ b/src/ui/diskdialog/diskcollectionpanel.tsx
@@ -499,7 +499,7 @@ const DiskCollectionPanel = (props: DiskCollectionPanelProps) => {
             onClick={(e) => {
               e.stopPropagation()
               handleCloudSignIn(providerName)
-            }}>Login</button>
+            }}>Sign in</button>
         </div>
       ))}
       <div className="disk-collection-panel"

--- a/src/ui/diskdialog/diskcollectionpanel.tsx
+++ b/src/ui/diskdialog/diskcollectionpanel.tsx
@@ -26,6 +26,11 @@ import { DiskPanelVtoc } from "./diskpanel_vtoc"
 
 const maxHdvBytes = 33554432
 
+// Fixed rendered height (px) of one auth notification bar. The disk collection
+// panel's height is reduced by this amount per visible bar so the overall dialog
+// height stays constant. Must match .dcp-auth-bar height in the CSS.
+const AUTH_BAR_HEIGHT = 32
+
 const minDate = new Date(0)
 const dateFormatter = new Intl.DateTimeFormat("en-US", {
   year: "2-digit",
@@ -51,9 +56,7 @@ const getSortModeForTab = (tabIndex: number): DiskCollectionSortMode => {
   return getPreferenceDiskCollectionSort(tabIndex) || defaultSortModeByTab[tabIndex] || "name-asc"
 }
 
-const createCloudProviderForItem = (item: DiskCollectionItem): CloudProvider | null => {
-  const providerName = item.cloudData?.providerName
-  if (!providerName) return null
+const createCloudProviderByName = (providerName: string): CloudProvider | null => {
   switch (providerName) {
     case "GoogleDrive":
       return new GoogleDrive()
@@ -62,6 +65,21 @@ const createCloudProviderForItem = (item: DiskCollectionItem): CloudProvider | n
     default:
       return null
   }
+}
+
+// Human-readable name for a cloud provider, used in the auth notification bar.
+const CLOUD_PROVIDER_DISPLAY_NAME: Record<string, string> = {
+  GoogleDrive: "Google Drive",
+  OneDrive: "OneDrive",
+}
+
+const cloudProviderDisplayName = (providerName: string): string =>
+  CLOUD_PROVIDER_DISPLAY_NAME[providerName] || providerName
+
+// Whether a cloud provider already has an access token cached in memory. Reading
+// this never triggers an auth popup.
+const cloudProviderHasAuthToken = (providerName: string): boolean => {
+  return createCloudProviderByName(providerName)?.hasAuthToken() ?? false
 }
 
 const requestCloudAuthTokenWithTimeout = (provider: CloudProvider, timeoutMs = 15000): Promise<boolean> => {
@@ -111,6 +129,10 @@ const DiskCollectionPanel = (props: DiskCollectionPanelProps) => {
   const [selectedDisks, setSelectedDisks] = useState<DiskCollectionItem[]>([])
   const [exportQueue, setExportQueue] = useState<DiskCollectionItem[]>([])
   const [downloadedDisks, setDownloadedDisks] = useState<DownloadedExportDisk[]>([])
+  // Bumped after a cloud sign-in completes so the render re-reads each provider's
+  // in-memory auth-token state (which lives outside React) to hide the auth
+  // notification bar and re-enable the Export button.
+  const [, setAuthRefresh] = useState<number>(0)
   const [pendingBookmarkRemovals, setPendingBookmarkRemovals] = useState<Set<string>>(new Set())
   const pendingBookmarkRemovalsRef = useRef<Set<string>>(new Set())
 
@@ -214,17 +236,11 @@ const DiskCollectionPanel = (props: DiskCollectionPanelProps) => {
   }
 
   const prepareSelectedItem = async (diskCollectionItem: DiskCollectionItem): Promise<DiskCollectionItem | null> => {
-    if (diskCollectionItem.type == DISK_COLLECTION_ITEM_TYPE.CLOUD_DRIVE && diskCollectionItem.cloudData) {
-      const cloudProvider = createCloudProviderForItem(diskCollectionItem)
-      if (cloudProvider) {
-        const authReady = await requestCloudAuthTokenWithTimeout(cloudProvider)
-        if (!authReady) {
-          alert("Cloud authorization did not complete. Please allow the provider popup and try selecting the disk again.")
-          return null
-        }
-      }
-    }
-
+    // Selecting a cloud disk must not trigger any auth or VTOC check. Its VTOC
+    // type was already determined (from the in-memory bytes) when it was
+    // bookmarked, and any sign-in is deferred to the notification bar's "Sign in"
+    // button (or the actual export). This keeps selection side-effect free and
+    // avoids background auth popups the browser would block.
     if (diskCollectionItem.cloudData && (!diskCollectionItem.cloudData.fileSize || diskCollectionItem.cloudData.fileSize <= 0)) {
       let fileSize = 0
 
@@ -348,8 +364,40 @@ const DiskCollectionPanel = (props: DiskCollectionPanelProps) => {
     return estimatedSize
   }
 
+  // Cloud providers that have at least one disk selected on the Export tab but
+  // still need a sign-in (no access token cached in memory). Drives both the auth
+  // notification bar and the Export button's disabled state. Reading the token
+  // state here never triggers an auth popup.
+  const selectedCloudProviderNames = Array.from(new Set(
+    selectedDisks
+      .filter((d) => d.type === DISK_COLLECTION_ITEM_TYPE.CLOUD_DRIVE && d.cloudData?.providerName)
+      .map((d) => d.cloudData!.providerName as string)
+  ))
+  const cloudProvidersNeedingAuth = selectedCloudProviderNames.filter(
+    (providerName) => !cloudProviderHasAuthToken(providerName)
+  )
+
+  const handleCloudSignIn = async (providerName: string) => {
+    const provider = createCloudProviderByName(providerName)
+    if (!provider) return
+    // Runs from an explicit "Sign in" click, so the provider popup is allowed.
+    const authReady = await requestCloudAuthTokenWithTimeout(provider)
+    if (authReady) {
+      // The token is now cached in memory; re-render so the bar hides and Export enables.
+      setAuthRefresh((n) => n + 1)
+    } else {
+      alert(`${cloudProviderDisplayName(providerName)} sign-in did not complete. Please allow the provider popup and try again.`)
+    }
+  }
+
   const isExportButtonDisabled = () => {
     const hdvSize = estimateHdvSize()
+
+    // Block export while any selected cloud disk's provider is not signed in;
+    // fetching that disk during export would fail (or trigger a blocked popup).
+    if (cloudProvidersNeedingAuth.length > 0) {
+      return true
+    }
 
     return hdvSize <= 0 || hdvSize > maxHdvBytes
   }
@@ -440,7 +488,24 @@ const DiskCollectionPanel = (props: DiskCollectionPanelProps) => {
           </div>
         ))}
       </div>
+      {activeTab == TAB_INDEX.EXPORT && cloudProvidersNeedingAuth.map((providerName) => (
+        <div
+          key={`dcp-auth-bar-${providerName}`}
+          className="dcp-auth-bar"
+          onClick={(e) => e.stopPropagation()}>
+          <span className="dcp-auth-bar-text">{`${cloudProviderDisplayName(providerName)} auth required`}</span>
+          <button
+            className="dcp-auth-bar-button"
+            onClick={(e) => {
+              e.stopPropagation()
+              handleCloudSignIn(providerName)
+            }}>Login</button>
+        </div>
+      ))}
       <div className="disk-collection-panel"
+        style={activeTab == TAB_INDEX.EXPORT && cloudProvidersNeedingAuth.length > 0
+          ? { height: `calc(65vh - ${cloudProvidersNeedingAuth.length * AUTH_BAR_HEIGHT}px)` }
+          : undefined}
         onClick={(e) => { if (e.target === e.currentTarget) e.stopPropagation() }}>
         {tabs[activeTab].disks.map((diskCollectionItem, index) => {
           const isExportTab = activeTab == TAB_INDEX.EXPORT

--- a/src/ui/diskdialog/diskpanel_vtoc.tsx
+++ b/src/ui/diskdialog/diskpanel_vtoc.tsx
@@ -206,15 +206,15 @@ export const DiskPanelVtoc = (props: DiskPanelVtocProps) => {
       // effect, so bump the pass counter explicitly.
       setVtocCheckPass((pass) => pass + 1)
     })
-    .catch(() => {
-      settled = true
-      // A rejected fetch is a definitive failure; remember it regardless of
-      // cancellation so it is never retried this session.
-      addSessionVtocFailure(pending.diskUrl.toString())
-      if (!cancelled) {
-        setVtocCheckPass((pass) => pass + 1)
-      }
-    })
+      .catch(() => {
+        settled = true
+        // A rejected fetch is a definitive failure; remember it regardless of
+        // cancellation so it is never retried this session.
+        addSessionVtocFailure(pending.diskUrl.toString())
+        if (!cancelled) {
+          setVtocCheckPass((pass) => pass + 1)
+        }
+      })
 
     return () => {
       cancelled = true
@@ -228,7 +228,7 @@ export const DiskPanelVtoc = (props: DiskPanelVtocProps) => {
         attempted.delete(pendingKey)
       }
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.activeTab, props.isFlyoutOpen, vtocCheckPass, props.exportQueue.length, props.downloadedDisks.length, visibleCandidatesKey])
 
   return (<></>)

--- a/src/ui/diskdialog/diskpanel_vtoc.tsx
+++ b/src/ui/diskdialog/diskpanel_vtoc.tsx
@@ -17,9 +17,6 @@ type DiskPanelVtocProps = {
   visibleCandidates: DiskCollectionItem[],
 }
 
-const BOOKMARK_VTOC_PAUSE_UNTIL_KEY = "diskcollection-vtoc-pause-until"
-const BOOKMARK_VTOC_SUPPRESS_WHILE_OPEN_KEY = "diskcollection-vtoc-suppress-while-open"
-
 // Downloads a disk's bytes without disturbing the running emulator. Unlike
 // loadDisk(), this never changes the run mode or loads the disk into a drive;
 // it simply resolves with the raw buffer (or null on failure) via callback.
@@ -83,6 +80,16 @@ export const DiskPanelVtoc = (props: DiskPanelVtocProps) => {
     props.setDiskCollection((prev) => [...prev])
   }
 
+  // A stable signature of the currently visible disks. Used as the effect
+  // dependency instead of the visibleCandidates array itself, whose identity
+  // changes on every parent render (it is produced by .filter()). Depending on
+  // the array identity re-ran the effect on every render, cancelling in-flight
+  // VTOC fetches before they could record a failure -- an infinite retry loop
+  // for un-fetchable (CORS/offline) disks.
+  const visibleCandidatesKey = props.visibleCandidates
+    .map((item) => item.diskUrl?.toString() || "")
+    .join("|")
+
   // While the Export tab is visible, fill in (and cache) the VTOC type of any
   // disk that doesn't already have one by downloading its bytes. This keeps VTOC
   // probing and its progress modal scoped to export workflows only. Built-in
@@ -103,29 +110,11 @@ export const DiskPanelVtoc = (props: DiskPanelVtocProps) => {
     // both themes, not just when isFlyoutOpen is toggled.
     const panelVisible = props.isFlyoutOpen || !isMinimalTheme()
     if (!panelVisible) {
-      sessionStorage.removeItem(BOOKMARK_VTOC_SUPPRESS_WHILE_OPEN_KEY)
       if (vtocProgressVisibleRef.current) {
         showGlobalProgressModal(false)
         vtocProgressVisibleRef.current = false
       }
       vtocActiveTabRef.current = null
-      return
-    }
-
-    if (sessionStorage.getItem(BOOKMARK_VTOC_SUPPRESS_WHILE_OPEN_KEY) === "1") {
-      if (vtocProgressVisibleRef.current) {
-        showGlobalProgressModal(false)
-        vtocProgressVisibleRef.current = false
-      }
-      return
-    }
-
-    const pauseUntil = Number(sessionStorage.getItem(BOOKMARK_VTOC_PAUSE_UNTIL_KEY) || 0)
-    if (Date.now() < pauseUntil) {
-      if (vtocProgressVisibleRef.current) {
-        showGlobalProgressModal(false)
-        vtocProgressVisibleRef.current = false
-      }
       return
     }
 
@@ -151,8 +140,14 @@ export const DiskPanelVtoc = (props: DiskPanelVtocProps) => {
     // superset of all exportable disks, but its rendered list is pre-filtered to
     // already-determined disks; use the full exportable candidate set for it so
     // its not-yet-determined disks still get resolved when it's navigated to.
+    // Cloud disks (Google Drive / OneDrive) are never background-probed here:
+    // fetching them requires an auth token and would trigger an auth popup. Their
+    // VTOC type is determined synchronously from the in-memory bytes when the
+    // bookmark is added, and any remaining auth happens when the disk is actually
+    // exported.
     const pendingCandidates = props.visibleCandidates.filter((item) =>
       item.vtocType === undefined &&
+      item.type !== DISK_COLLECTION_ITEM_TYPE.CLOUD_DRIVE &&
       isDiskExportable(item) &&
       !hasSessionVtocFailure(item.diskUrl.toString())
     )
@@ -188,25 +183,35 @@ export const DiskPanelVtoc = (props: DiskPanelVtocProps) => {
 
     fetchDiskBufferForItem(pending).then((data) => {
       settled = true
-      if (cancelled) {
-        return
-      }
       if (!data) {
         // Download failed (CORS/network). Remember the failure for this browser
-        // session so we don't re-attempt the download on every reload, then
-        // advance to the next disk. It will be retried in a new session.
+        // session -- even if this effect was cancelled/re-run in the meantime --
+        // so it is not re-attempted on every render (an infinite retry loop) or
+        // on reload. It is retried in a new session. Only advance the pass when
+        // still mounted; a cancelled run's successor will pick the next disk.
         addSessionVtocFailure(pending.diskUrl.toString())
-        setVtocCheckPass((pass) => pass + 1)
+        if (!cancelled) {
+          setVtocCheckPass((pass) => pass + 1)
+        }
+        return
+      }
+      if (cancelled) {
         return
       }
       const filename = getExportFilename(pending, data)
       // Cache the determined VTOC (and persist it for bookmarks).
       persistVtocType(pending, determineVtocType(filename, data))
+      // Advance to the next pending disk. We no longer rely on the collection
+      // re-render (which changes visibleCandidates identity) to re-run this
+      // effect, so bump the pass counter explicitly.
+      setVtocCheckPass((pass) => pass + 1)
     })
     .catch(() => {
       settled = true
+      // A rejected fetch is a definitive failure; remember it regardless of
+      // cancellation so it is never retried this session.
+      addSessionVtocFailure(pending.diskUrl.toString())
       if (!cancelled) {
-        addSessionVtocFailure(pending.diskUrl.toString())
         setVtocCheckPass((pass) => pass + 1)
       }
     })
@@ -224,7 +229,7 @@ export const DiskPanelVtoc = (props: DiskPanelVtocProps) => {
       }
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.activeTab, props.isFlyoutOpen, vtocCheckPass, props.exportQueue.length, props.downloadedDisks.length, props.visibleCandidates])
+  }, [props.activeTab, props.isFlyoutOpen, vtocCheckPass, props.exportQueue.length, props.downloadedDisks.length, visibleCandidatesKey])
 
   return (<></>)
 }

--- a/src/ui/diskdialog/diskpanel_vtoc.tsx
+++ b/src/ui/diskdialog/diskpanel_vtoc.tsx
@@ -18,6 +18,7 @@ type DiskPanelVtocProps = {
 }
 
 const BOOKMARK_VTOC_PAUSE_UNTIL_KEY = "diskcollection-vtoc-pause-until"
+const BOOKMARK_VTOC_SUPPRESS_WHILE_OPEN_KEY = "diskcollection-vtoc-suppress-while-open"
 
 // Downloads a disk's bytes without disturbing the running emulator. Unlike
 // loadDisk(), this never changes the run mode or loads the disk into a drive;
@@ -51,11 +52,6 @@ export const DiskPanelVtoc = (props: DiskPanelVtocProps) => {
   // a fresh pass for the newly visible disks.
   const vtocActiveTabRef = useRef<number | null>(null)
   const vtocProgressVisibleRef = useRef(false)
-  // True while a single background probe download is in flight. Guarantees only
-  // one probe runs at a time, so the effect re-running (its visibleCandidates
-  // dependency is a fresh array on every parent render, which happens
-  // constantly while the emulator runs) can't launch overlapping downloads.
-  const vtocFetchInFlightRef = useRef(false)
 
   // Stable identity for a disk across re-renders (bookmark id, cloud item id,
   // disk URL, or finally the title).
@@ -107,11 +103,20 @@ export const DiskPanelVtoc = (props: DiskPanelVtocProps) => {
     // both themes, not just when isFlyoutOpen is toggled.
     const panelVisible = props.isFlyoutOpen || !isMinimalTheme()
     if (!panelVisible) {
+      sessionStorage.removeItem(BOOKMARK_VTOC_SUPPRESS_WHILE_OPEN_KEY)
       if (vtocProgressVisibleRef.current) {
         showGlobalProgressModal(false)
         vtocProgressVisibleRef.current = false
       }
       vtocActiveTabRef.current = null
+      return
+    }
+
+    if (sessionStorage.getItem(BOOKMARK_VTOC_SUPPRESS_WHILE_OPEN_KEY) === "1") {
+      if (vtocProgressVisibleRef.current) {
+        showGlobalProgressModal(false)
+        vtocProgressVisibleRef.current = false
+      }
       return
     }
 
@@ -154,15 +159,6 @@ export const DiskPanelVtoc = (props: DiskPanelVtocProps) => {
     const pending = pendingCandidates.find((item) =>
       !vtocResolveAttempted.current.has(itemKey(item))
     )
-
-    // Only one probe download runs at a time. If one is already in flight, wait
-    // for it to settle (it bumps vtocCheckPass, re-running this effect to pick
-    // the next disk). This is what keeps a constantly re-running effect from
-    // starting a flood of duplicate downloads for the same disk.
-    if (vtocFetchInFlightRef.current) {
-      return
-    }
-
     if (!pending) {
       if (vtocProgressVisibleRef.current) {
         showGlobalProgressModal(false)
@@ -183,33 +179,50 @@ export const DiskPanelVtoc = (props: DiskPanelVtocProps) => {
     }
 
     vtocResolveAttempted.current.add(itemKey(pending))
-    vtocFetchInFlightRef.current = true
-    // Capture the item so the async handlers don't depend on the changing
-    // `pending` binding. The fetch always runs to completion (it is never
-    // cancelled): on success it caches the VTOC type, on failure it records a
-    // session failure so hasSessionVtocFailure() filters the disk out and it is
-    // never re-downloaded this session. The disk also stays marked in
-    // `attempted`, so it is not re-picked while the fetch is in flight -- this
-    // is what stopped the infinite re-fetch loop for un-fetchable disks.
-    const probing = pending
+    // Capture the ref's Set (stable across renders) and the item key so the
+    // cleanup below doesn't read a ref during teardown (which lint flags).
+    const attempted = vtocResolveAttempted.current
+    const pendingKey = itemKey(pending)
+    let cancelled = false
+    let settled = false
 
-    fetchDiskBufferForItem(probing).then((data) => {
-      if (!data) {
-        addSessionVtocFailure(probing.diskUrl.toString())
+    fetchDiskBufferForItem(pending).then((data) => {
+      settled = true
+      if (cancelled) {
         return
       }
-      const filename = getExportFilename(probing, data)
+      if (!data) {
+        // Download failed (CORS/network). Remember the failure for this browser
+        // session so we don't re-attempt the download on every reload, then
+        // advance to the next disk. It will be retried in a new session.
+        addSessionVtocFailure(pending.diskUrl.toString())
+        setVtocCheckPass((pass) => pass + 1)
+        return
+      }
+      const filename = getExportFilename(pending, data)
       // Cache the determined VTOC (and persist it for bookmarks).
-      persistVtocType(probing, determineVtocType(filename, data))
+      persistVtocType(pending, determineVtocType(filename, data))
     })
     .catch(() => {
-      addSessionVtocFailure(probing.diskUrl.toString())
+      settled = true
+      if (!cancelled) {
+        addSessionVtocFailure(pending.diskUrl.toString())
+        setVtocCheckPass((pass) => pass + 1)
+      }
     })
-    .finally(() => {
-      vtocFetchInFlightRef.current = false
-      // Advance to the next pending disk.
-      setVtocCheckPass((pass) => pass + 1)
-    })
+
+    return () => {
+      cancelled = true
+      // If this effect re-ran (e.g. diskCollection changed during the panel-open
+      // re-render storm) before the fetch settled, un-mark the disk so it is
+      // retried on the next pass. Otherwise it would be stranded with an
+      // undefined VTOC -- showing a non-exportable badge until the panel is
+      // reopened. This most often struck the first disk, whose fetch is in flight
+      // exactly while the collection is still settling.
+      if (!settled) {
+        attempted.delete(pendingKey)
+      }
+    }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.activeTab, props.isFlyoutOpen, vtocCheckPass, props.exportQueue.length, props.downloadedDisks.length, props.visibleCandidates])
 

--- a/src/ui/diskdialog/diskpanel_vtoc.tsx
+++ b/src/ui/diskdialog/diskpanel_vtoc.tsx
@@ -18,7 +18,6 @@ type DiskPanelVtocProps = {
 }
 
 const BOOKMARK_VTOC_PAUSE_UNTIL_KEY = "diskcollection-vtoc-pause-until"
-const BOOKMARK_VTOC_SUPPRESS_WHILE_OPEN_KEY = "diskcollection-vtoc-suppress-while-open"
 
 // Downloads a disk's bytes without disturbing the running emulator. Unlike
 // loadDisk(), this never changes the run mode or loads the disk into a drive;
@@ -52,6 +51,11 @@ export const DiskPanelVtoc = (props: DiskPanelVtocProps) => {
   // a fresh pass for the newly visible disks.
   const vtocActiveTabRef = useRef<number | null>(null)
   const vtocProgressVisibleRef = useRef(false)
+  // True while a single background probe download is in flight. Guarantees only
+  // one probe runs at a time, so the effect re-running (its visibleCandidates
+  // dependency is a fresh array on every parent render, which happens
+  // constantly while the emulator runs) can't launch overlapping downloads.
+  const vtocFetchInFlightRef = useRef(false)
 
   // Stable identity for a disk across re-renders (bookmark id, cloud item id,
   // disk URL, or finally the title).
@@ -103,20 +107,11 @@ export const DiskPanelVtoc = (props: DiskPanelVtocProps) => {
     // both themes, not just when isFlyoutOpen is toggled.
     const panelVisible = props.isFlyoutOpen || !isMinimalTheme()
     if (!panelVisible) {
-      sessionStorage.removeItem(BOOKMARK_VTOC_SUPPRESS_WHILE_OPEN_KEY)
       if (vtocProgressVisibleRef.current) {
         showGlobalProgressModal(false)
         vtocProgressVisibleRef.current = false
       }
       vtocActiveTabRef.current = null
-      return
-    }
-
-    if (sessionStorage.getItem(BOOKMARK_VTOC_SUPPRESS_WHILE_OPEN_KEY) === "1") {
-      if (vtocProgressVisibleRef.current) {
-        showGlobalProgressModal(false)
-        vtocProgressVisibleRef.current = false
-      }
       return
     }
 
@@ -159,6 +154,15 @@ export const DiskPanelVtoc = (props: DiskPanelVtocProps) => {
     const pending = pendingCandidates.find((item) =>
       !vtocResolveAttempted.current.has(itemKey(item))
     )
+
+    // Only one probe download runs at a time. If one is already in flight, wait
+    // for it to settle (it bumps vtocCheckPass, re-running this effect to pick
+    // the next disk). This is what keeps a constantly re-running effect from
+    // starting a flood of duplicate downloads for the same disk.
+    if (vtocFetchInFlightRef.current) {
+      return
+    }
+
     if (!pending) {
       if (vtocProgressVisibleRef.current) {
         showGlobalProgressModal(false)
@@ -179,50 +183,33 @@ export const DiskPanelVtoc = (props: DiskPanelVtocProps) => {
     }
 
     vtocResolveAttempted.current.add(itemKey(pending))
-    // Capture the ref's Set (stable across renders) and the item key so the
-    // cleanup below doesn't read a ref during teardown (which lint flags).
-    const attempted = vtocResolveAttempted.current
-    const pendingKey = itemKey(pending)
-    let cancelled = false
-    let settled = false
+    vtocFetchInFlightRef.current = true
+    // Capture the item so the async handlers don't depend on the changing
+    // `pending` binding. The fetch always runs to completion (it is never
+    // cancelled): on success it caches the VTOC type, on failure it records a
+    // session failure so hasSessionVtocFailure() filters the disk out and it is
+    // never re-downloaded this session. The disk also stays marked in
+    // `attempted`, so it is not re-picked while the fetch is in flight -- this
+    // is what stopped the infinite re-fetch loop for un-fetchable disks.
+    const probing = pending
 
-    fetchDiskBufferForItem(pending).then((data) => {
-      settled = true
-      if (cancelled) {
-        return
-      }
+    fetchDiskBufferForItem(probing).then((data) => {
       if (!data) {
-        // Download failed (CORS/network). Remember the failure for this browser
-        // session so we don't re-attempt the download on every reload, then
-        // advance to the next disk. It will be retried in a new session.
-        addSessionVtocFailure(pending.diskUrl.toString())
-        setVtocCheckPass((pass) => pass + 1)
+        addSessionVtocFailure(probing.diskUrl.toString())
         return
       }
-      const filename = getExportFilename(pending, data)
+      const filename = getExportFilename(probing, data)
       // Cache the determined VTOC (and persist it for bookmarks).
-      persistVtocType(pending, determineVtocType(filename, data))
+      persistVtocType(probing, determineVtocType(filename, data))
     })
     .catch(() => {
-      settled = true
-      if (!cancelled) {
-        addSessionVtocFailure(pending.diskUrl.toString())
-        setVtocCheckPass((pass) => pass + 1)
-      }
+      addSessionVtocFailure(probing.diskUrl.toString())
     })
-
-    return () => {
-      cancelled = true
-      // If this effect re-ran (e.g. diskCollection changed during the panel-open
-      // re-render storm) before the fetch settled, un-mark the disk so it is
-      // retried on the next pass. Otherwise it would be stranded with an
-      // undefined VTOC -- showing a non-exportable badge until the panel is
-      // reopened. This most often struck the first disk, whose fetch is in flight
-      // exactly while the collection is still settling.
-      if (!settled) {
-        attempted.delete(pendingKey)
-      }
-    }
+    .finally(() => {
+      vtocFetchInFlightRef.current = false
+      // Advance to the next pending disk.
+      setVtocCheckPass((pass) => pass + 1)
+    })
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.activeTab, props.isFlyoutOpen, vtocCheckPass, props.exportQueue.length, props.downloadedDisks.length, props.visibleCandidates])
 


### PR DESCRIPTION
<img width="1832" height="1521" alt="Screenshot 2026-07-06 at 2 52 51 PM" src="https://github.com/user-attachments/assets/5fd8a0b8-d876-45a2-ac83-6f4e5fe571b5" />
<img width="1832" height="1521" alt="image" src="https://github.com/user-attachments/assets/0abdc8d2-17a4-42c3-9dc3-5b0363f31497" />
<img width="1832" height="1521" alt="Screenshot 2026-07-06 at 2 56 14 PM" src="https://github.com/user-attachments/assets/a39e57c4-858b-41e7-95c1-757426a653d7" />
<img width="438" height="937" alt="image" src="https://github.com/user-attachments/assets/ce0ae38b-853e-4a03-a723-6a1564d45d9a" />

Changes:
- Updated disk menu to use drive data rather than fetch to determine VTOC when bookmarking cloud disk
- Disabled VOTC check for cloud disks in export tab
- Created notification bar when cloud drive auth is required