### PR TITLE
Request external MIDI access on demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ the "test" script, and select 'Debug Script'.
 
 ## Testing
 
+### MIDI Testing
+
+Apple2TS uses its built-in software synthesizer by default. Selecting **Enable External MIDI…** from the **Audio Configuration** menu may trigger a browser permission prompt before external MIDI outputs are listed. If the selected output disappears, Apple2TS returns to its built-in synthesizer. On macOS, the [built-in IAC Driver](https://support.apple.com/guide/audio-midi-setup/transfer-midi-information-between-apps-ams1013/mac) can provide virtual MIDI buses for testing.
+
 ### If you change disk drive code
 
 1. Press _Boot_ then _Reset_, type some characters, click on _File save_ button, verify `apple2ts.a2ts` is downloaded.

--- a/src/common/custom.d.ts
+++ b/src/common/custom.d.ts
@@ -395,6 +395,8 @@ interface OpenerWindow {
 
 type PopupMenuItem = {
   label: string,
+  isDisabled?: boolean,
+  isHeading?: boolean,
   icon?: IconDefinition,
   svg?: JSX.Element,
   isVisible?: () => boolean,

--- a/src/ui/controls/popupmenu.tsx
+++ b/src/ui/controls/popupmenu.tsx
@@ -28,7 +28,7 @@ const PopupMenu = (props: PopupMenuProps) => {
         h += 12
       } else {
         w = Math.max(w, menuItem.label.length * 10)
-        h += 26
+        h += menuItem.isHeading ? 24 : 26
       }
     })
     h += 22
@@ -55,13 +55,37 @@ const PopupMenu = (props: PopupMenuProps) => {
                 key={`popup-${menuIndex}-${menuIndex}`}
                 style={{ borderTop: "1px solid #aaa", margin: "5px 0" }}>
               </div>
+              : menuItem.isHeading
+                ? <div
+                  key={`popup-${menuIndex}-${menuIndex}`}
+                  style={{
+                    cursor: "default",
+                    fontWeight: 800,
+                    padding: "5px 8px 2px",
+                  }}>
+                  {menuItem.label}
+                </div>
               : <div
                 key={`popup-${menuIndex}-${menuIndex}`}
-                className="droplist-option" style={{ padding: "5px" }}
-                onMouseOver={(e) => e.currentTarget.style.backgroundColor = "#ccc"}
-                onMouseOut={(e) => e.currentTarget.style.backgroundColor = "inherit"}
+                aria-disabled={menuItem.isDisabled || undefined}
+                className="droplist-option"
+                style={{
+                  cursor: menuItem.isDisabled ? "default" : "pointer",
+                  opacity: menuItem.isDisabled ? 0.5 : 1,
+                  padding: "5px",
+                }}
+                onMouseOver={(e) => {
+                  if (!menuItem.isDisabled)
+                    e.currentTarget.style.backgroundColor = "#ccc"
+                }}
+                onMouseOut={(e) => {
+                  if (!menuItem.isDisabled)
+                    e.currentTarget.style.backgroundColor = "inherit"
+                }}
                 onClick={async (e) => {
                   e.stopPropagation()
+                  if (menuItem.isDisabled)
+                    return
                   if (menuItem.onClick) {
                     await menuItem.onClick()
                   }

--- a/src/ui/devices/audio/audioconfig.tsx
+++ b/src/ui/devices/audio/audioconfig.tsx
@@ -6,7 +6,7 @@ import {
   faMusic,
 } from "@fortawesome/free-solid-svg-icons"
 import PopupMenu from "../../controls/popupmenu"
-import { getMidiCurrentIndex, getMidiDeviceNames, handleMidiDeviceSelect } from "./midiselect"
+import { getMidiDeviceOptions, handleMidiDeviceSelect, isMidiDeviceSelected } from "./midiselect"
 
 export const AudioConfig = () => {
   const [popupLocation, setPopupLocation] = useState<[number, number]>()
@@ -15,7 +15,7 @@ export const AudioConfig = () => {
     setPopupLocation([event.clientX, event.clientY])
   }
 
-  const midiNames = getMidiDeviceNames()
+  const midiOptions = getMidiDeviceOptions()
 
   return (
     <span>
@@ -32,9 +32,10 @@ export const AudioConfig = () => {
         location={popupLocation}
         onClose={() => { setPopupLocation(undefined) }}
         menuItems={[[
+          { label: "Mockingboard", isHeading: true },
           ...Array.from(Array(MockingboardNames.length).keys()).map((i) => (
             {
-              label: `Mockingboard ${MockingboardNames[i]}`,
+              label: MockingboardNames[i],
               isSelected: () => { return i === getMockingboardMode() },
               onClick: () => {
                 setPreferenceMockingboardMode(i)
@@ -42,12 +43,14 @@ export const AudioConfig = () => {
             }
           )),
           ...[{ label: "-" }],
-          ...Array.from(Array(midiNames.length).keys()).map((i) => (
+          { label: "MIDI", isHeading: true },
+          ...midiOptions.map((option) => (
             {
-              label: `MIDI ${midiNames[i]}`,
-              isSelected: () => { return i === getMidiCurrentIndex() },
-              onClick: () => {
-                handleMidiDeviceSelect(i)
+              label: option.label,
+              isDisabled: option.type === "unavailable",
+              isSelected: () => { return isMidiDeviceSelected(option) },
+              onClick: async () => {
+                await handleMidiDeviceSelect(option)
               }
             }
           ))

--- a/src/ui/devices/audio/midiinterface.test.ts
+++ b/src/ui/devices/audio/midiinterface.test.ts
@@ -1,0 +1,215 @@
+jest.mock("../../main2worker", () => ({
+  passRxMidiData: jest.fn(),
+}))
+
+jest.mock("./enhancedmidi", () => ({
+  checkEnhancedMidi: jest.fn(() => false),
+}))
+
+jest.mock("./softsynth", () => ({
+  initSoftSynth: jest.fn(),
+  isSoftSynthAvailable: jest.fn(() => true),
+  stopAllNotes: jest.fn(),
+}))
+
+const createMidiAccess = () => {
+  const outputA = { id: "output-a", name: "Test MIDI Output A" } as MIDIOutput
+  const outputB = { id: "output-b", name: "Test MIDI Output B" } as MIDIOutput
+  return {
+    inputs: new Map(),
+    outputs: new Map([["output-a", outputA], ["output-b", outputB]]),
+    addEventListener: jest.fn(),
+  } as unknown as MIDIAccess
+}
+
+const triggerStateChange = (midiAccess: MIDIAccess) => {
+  const stateChange = (midiAccess.addEventListener as jest.Mock).mock.calls[0][1]
+  stateChange()
+}
+
+beforeEach(() => {
+  jest.resetModules()
+  jest.spyOn(console, "log").mockImplementation(() => undefined)
+  jest.spyOn(console, "warn").mockImplementation(() => undefined)
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+test("does not request MIDI permission when the module loads", async () => {
+  const requestMIDIAccess = jest.fn(() => Promise.resolve(createMidiAccess()))
+  Object.defineProperty(navigator, "requestMIDIAccess", {
+    value: requestMIDIAccess,
+    configurable: true,
+  })
+
+  const midiSelect = await import("./midiselect")
+
+  expect(requestMIDIAccess).not.toHaveBeenCalled()
+  const options = midiSelect.getMidiDeviceOptions()
+  expect(options.map((option) => option.label)).toEqual([
+    "Apple2TS Built-in Synthesizer", "Enable External MIDI…",
+  ])
+  expect(midiSelect.isMidiDeviceSelected(options[0])).toBe(true)
+  expect(midiSelect.isMidiDeviceSelected(options[1])).toBe(false)
+})
+
+test("does not offer external MIDI when Web MIDI is unsupported", async () => {
+  Object.defineProperty(navigator, "requestMIDIAccess", {
+    value: undefined,
+    configurable: true,
+  })
+
+  const midiSelect = await import("./midiselect")
+
+  expect(midiSelect.getMidiDeviceOptions().map((option) => option.label)).toEqual([
+    "Apple2TS Built-in Synthesizer",
+  ])
+})
+
+test("requests MIDI permission only when Web MIDI access is requested", async () => {
+  const midiAccess = createMidiAccess()
+  const requestMIDIAccess = jest.fn(() => Promise.resolve(midiAccess))
+  Object.defineProperty(navigator, "requestMIDIAccess", {
+    value: requestMIDIAccess,
+    configurable: true,
+  })
+  const midi = await import("./midiinterface")
+  const midiSelect = await import("./midiselect")
+  const enableExternal = midiSelect.getMidiDeviceOptions()
+    .find((option) => option.type === "enable-web-midi")
+
+  expect(enableExternal).toBeDefined()
+  await midiSelect.handleMidiDeviceSelect(enableExternal!)
+
+  expect(requestMIDIAccess).toHaveBeenCalledTimes(1)
+  expect(requestMIDIAccess).toHaveBeenCalledWith({ sysex: true })
+  expect(midi.midiOutDevices).toHaveLength(2)
+
+  const options = midiSelect.getMidiDeviceOptions()
+  expect(options.map((option) => option.type)).toEqual([
+    "built-in-synth", "web-midi-output", "web-midi-output",
+  ])
+  expect(options[0].label).toBe("Apple2TS Built-in Synthesizer")
+  expect(midiSelect.isMidiDeviceSelected(options[0])).toBe(false)
+  expect(options[1].label).toBe("Test MIDI Output A")
+  expect(midiSelect.isMidiDeviceSelected(options[1])).toBe(true)
+  expect(midiSelect.isMidiDeviceSelected(options[2])).toBe(false)
+  expect(midi.setMidiOutIndex(99)).toBe(false)
+  expect(midi.getMidiOutIndex()).toBe(0)
+  expect(console.warn).toHaveBeenCalledWith(
+    "Cannot select MIDI output index 99; selection unchanged."
+  )
+
+  await expect(midi.requestWebMidiAccess()).resolves.toBe(true)
+  expect(requestMIDIAccess).toHaveBeenCalledTimes(1)
+})
+
+test("warns and falls back when the selected output disappears", async () => {
+  const midiAccess = createMidiAccess()
+  Object.defineProperty(navigator, "requestMIDIAccess", {
+    value: jest.fn(() => Promise.resolve(midiAccess)),
+    configurable: true,
+  })
+  const midiSelect = await import("./midiselect")
+  const enableExternal = midiSelect.getMidiDeviceOptions()
+    .find((option) => option.type === "enable-web-midi")
+
+  await midiSelect.handleMidiDeviceSelect(enableExternal!)
+  expect(midiSelect.isMidiDeviceSelected(midiSelect.getMidiDeviceOptions()[1])).toBe(true)
+
+  const outputs = midiAccess.outputs as Map<string, MIDIOutput>
+  outputs.delete("output-a")
+  triggerStateChange(midiAccess)
+
+  const options = midiSelect.getMidiDeviceOptions()
+  expect(options.map((option) => option.label)).toEqual([
+    "Apple2TS Built-in Synthesizer", "Test MIDI Output B",
+  ])
+  expect(midiSelect.isMidiDeviceSelected(options[0])).toBe(true)
+  expect(midiSelect.isMidiDeviceSelected(options[1])).toBe(false)
+  expect(console.warn).toHaveBeenCalledWith(
+    "MIDI output \"Test MIDI Output A\" is no longer available; using the built-in synthesizer."
+  )
+})
+
+test("preserves the selected output by ID when another output disappears", async () => {
+  const midiAccess = createMidiAccess()
+  Object.defineProperty(navigator, "requestMIDIAccess", {
+    value: jest.fn(() => Promise.resolve(midiAccess)),
+    configurable: true,
+  })
+  const midiSelect = await import("./midiselect")
+  const enableExternal = midiSelect.getMidiDeviceOptions()
+    .find((option) => option.type === "enable-web-midi")
+
+  await midiSelect.handleMidiDeviceSelect(enableExternal!)
+  const outputB = midiSelect.getMidiDeviceOptions()
+    .find((option) => option.type === "web-midi-output" && option.deviceId === "output-b")
+  await midiSelect.handleMidiDeviceSelect(outputB!)
+
+  const outputs = midiAccess.outputs as Map<string, MIDIOutput>
+  outputs.delete("output-a")
+  triggerStateChange(midiAccess)
+
+  const options = midiSelect.getMidiDeviceOptions()
+  expect(options.map((option) => option.label)).toEqual([
+    "Apple2TS Built-in Synthesizer", "Test MIDI Output B",
+  ])
+  expect(midiSelect.isMidiDeviceSelected(options[0])).toBe(false)
+  expect(midiSelect.isMidiDeviceSelected(options[1])).toBe(true)
+  expect(console.warn).not.toHaveBeenCalled()
+})
+
+test("ignores a stale menu option after its output disappears", async () => {
+  const midiAccess = createMidiAccess()
+  Object.defineProperty(navigator, "requestMIDIAccess", {
+    value: jest.fn(() => Promise.resolve(midiAccess)),
+    configurable: true,
+  })
+  const midiSelect = await import("./midiselect")
+  const enableExternal = midiSelect.getMidiDeviceOptions()
+    .find((option) => option.type === "enable-web-midi")
+
+  await midiSelect.handleMidiDeviceSelect(enableExternal!)
+  const staleOutput = midiSelect.getMidiDeviceOptions()
+    .find((option) => option.type === "web-midi-output" && option.deviceId === "output-a")
+  const outputs = midiAccess.outputs as Map<string, MIDIOutput>
+  outputs.delete("output-a")
+  triggerStateChange(midiAccess)
+  const warnMock = console.warn as jest.Mock
+  warnMock.mockClear()
+
+  await midiSelect.handleMidiDeviceSelect(staleOutput!)
+
+  const options = midiSelect.getMidiDeviceOptions()
+  expect(midiSelect.isMidiDeviceSelected(options[0])).toBe(true)
+  expect(midiSelect.isMidiDeviceSelected(options[1])).toBe(false)
+  expect(console.warn).toHaveBeenCalledWith(
+    "MIDI output \"Test MIDI Output A\" is no longer available; selection unchanged."
+  )
+})
+
+test("warns when a disconnected output has no built-in fallback", async () => {
+  const midiAccess = createMidiAccess()
+  Object.defineProperty(navigator, "requestMIDIAccess", {
+    value: jest.fn(() => Promise.resolve(midiAccess)),
+    configurable: true,
+  })
+  const softSynth = await import("./softsynth")
+  const midiSelect = await import("./midiselect")
+  const enableExternal = midiSelect.getMidiDeviceOptions()
+    .find((option) => option.type === "enable-web-midi")
+
+  await midiSelect.handleMidiDeviceSelect(enableExternal!)
+  const isSoftSynthAvailable = softSynth.isSoftSynthAvailable as jest.Mock
+  isSoftSynthAvailable.mockReturnValue(false)
+  const outputs = midiAccess.outputs as Map<string, MIDIOutput>
+  outputs.delete("output-a")
+  triggerStateChange(midiAccess)
+
+  expect(console.warn).toHaveBeenCalledWith(
+    "MIDI output \"Test MIDI Output A\" is no longer available; no MIDI output is selected."
+  )
+})

--- a/src/ui/devices/audio/midiinterface.ts
+++ b/src/ui/devices/audio/midiinterface.ts
@@ -5,23 +5,8 @@ import * as SoftSynth from "./softsynth"
 let useSoftSynth = true
 const DEBUG = false
 
-const connect = () => {
-  if (navigator.requestMIDIAccess)
-  {
-    console.log("Midi Connect")
-    navigator.requestMIDIAccess({ sysex: true })
-    .then(
-      (midi) => midiReady(midi),
-      (err) => console.log("requestMIDIAccess fails", err))
-  }
-  else
-    console.log("WebMidi not supported") 
-}
-
-// execute on load
-connect()
-
-let midiAccess: MIDIAccess
+let midiAccess: MIDIAccess | undefined
+let midiAccessRequest: Promise<boolean> | undefined
 
 const midiReady = (midi: MIDIAccess) => {
   // Also react to device changes.
@@ -32,20 +17,64 @@ const midiReady = (midi: MIDIAccess) => {
 
 let midiInIndex  = -1
 let midiOutIndex = -1
-export let midiInDevices: MIDIInput[]
-export let midiOutDevices: MIDIOutput[]
+export let midiInDevices: MIDIInput[] = []
+export let midiOutDevices: MIDIOutput[] = []
+
+export const isWebMidiSupported = () => {
+  return typeof navigator !== "undefined" && !!navigator.requestMIDIAccess
+}
+
+export const hasWebMidiAccess = () => {
+  return midiAccess !== undefined
+}
+
+export const requestWebMidiAccess = async (): Promise<boolean> => {
+  if (midiAccess)
+    return true
+
+  if (!isWebMidiSupported()) {
+    console.log("Web MIDI not supported")
+    return false
+  }
+
+  if (midiAccessRequest)
+    return midiAccessRequest
+
+  console.log("Requesting MIDI access")
+  midiAccessRequest = navigator.requestMIDIAccess({ sysex: true })
+    .then((midi) => {
+      midiReady(midi)
+      return true
+    })
+    .catch((err) => {
+      console.log("requestMIDIAccess fails", err)
+      return false
+    })
+
+  try {
+    return await midiAccessRequest
+  } finally {
+    midiAccessRequest = undefined
+  }
+}
 
 export const getMidiOutIndex = (): number => {
   return midiOutIndex
 }
 
 export const setMidiOutIndex = (index: number) => {
+  if (index < -1 || index >= midiOutDevices.length) {
+    console.warn(`Cannot select MIDI output index ${index}; selection unchanged.`)
+    return false
+  }
+
   if (midiOutIndex != index)
   {
     midiOutIndex = index
     if (midiOutIndex != -1)
-      console.log("Selecting MidiOut Device: " + midiOutDevices[midiOutIndex].name)
+      console.log("Selecting MIDI output: " + midiOutDevices[midiOutIndex].name)
   }
+  return true
 }
 
 export const getMidiInIndex = (): number => {
@@ -63,10 +92,25 @@ export const setMidiInIndex = (index: number) => {
 
 const initDevices = () => {
 
-  const midi: MIDIAccess = midiAccess
+  const midi = midiAccess
 
   if (!midi)
     return
+
+  const selectedOutput = midiOutDevices[midiOutIndex]
+  const selectedOutputId = selectedOutput?.id
+  const fallbackToBuiltInSynth = () => {
+    midiOutIndex = -1
+    if (!useSoftSynth) {
+      const outputName = selectedOutput?.name || "Unknown MIDI Output"
+      if (SoftSynth.isSoftSynthAvailable()) {
+        console.warn(`MIDI output "${outputName}" is no longer available; using the built-in synthesizer.`)
+        enableSoftSynth()
+      } else {
+        console.warn(`MIDI output "${outputName}" is no longer available; no MIDI output is selected.`)
+      }
+    }
+  }
 
   // Reset.
   midiInDevices = []
@@ -74,19 +118,28 @@ const initDevices = () => {
 
   const outputs = midi.outputs.values()
   for (let output = outputs.next(); output && !output.done; output = outputs.next()) {
-    //console.log("Midi Out: " + output.value.name);
-    midiOutDevices.push(output.value)
+    if (output.value.state !== "disconnected")
+      midiOutDevices.push(output.value)
   }
 
   if (midiOutDevices.length)
   {
-    // pick last one
-    if (midiOutIndex != midiOutDevices.length-1)
+    if (selectedOutputId !== undefined)
     {
-      midiOutIndex = midiOutDevices.length-1
-      const device = midiOutDevices[midiOutIndex]
-      console.log("Selecting MidiOutDevice: " + device.name)
+      midiOutIndex = midiOutDevices.findIndex((device) => device.id === selectedOutputId)
+      if (midiOutIndex === -1)
+        fallbackToBuiltInSynth()
     }
+    else
+    {
+      midiOutIndex = 0
+      const device = midiOutDevices[midiOutIndex]
+      console.log("Selecting MIDI output: " + device.name)
+    }
+  }
+  else
+  {
+    fallbackToBuiltInSynth()
   }
   
   const inputs = midi.inputs.values()
@@ -130,7 +183,7 @@ const activeSense = () => {
 }
 
 const parseAndSendMsg = (msg: number[]) => {
-  // Determine the output device (hardware MIDI or software synth)
+  // Determine the output device (Web MIDI or built-in synth)
   const device = (useSoftSynth || midiOutIndex === -1) 
     ? SoftSynth as unknown as MIDIOutput  // Software synth has compatible send() API
     : midiOutDevices[midiOutIndex]
@@ -167,7 +220,7 @@ const rtMsg: number[] = []
 let state : State = State.COMMAND
 
 export const receiveMidiData = (data: Uint8Array) => {
-  // Initialize software synth if needed and no hardware MIDI available
+  // Fall back to the built-in synth if no external output is selected.
   if (midiOutIndex === -1 && !useSoftSynth && SoftSynth.isSoftSynthAvailable()) {
     console.log("No MIDI interface detected. Using built-in software synthesizer.")
     SoftSynth.initSoftSynth()
@@ -309,4 +362,3 @@ export const isSoftSynthAvailable = () => {
 export const setSoftSynthMasterVolume = (volume: number) => {
   SoftSynth.setMasterVolume(volume)
 }
-

--- a/src/ui/devices/audio/midiselect.ts
+++ b/src/ui/devices/audio/midiselect.ts
@@ -1,46 +1,87 @@
-import { midiOutDevices, getMidiOutIndex, setMidiOutIndex, isSoftSynthEnabled, isSoftSynthAvailable, enableSoftSynth, disableSoftSynth } from "./midiinterface"
+import {
+  midiOutDevices,
+  getMidiOutIndex,
+  setMidiOutIndex,
+  isSoftSynthEnabled,
+  isSoftSynthAvailable,
+  enableSoftSynth,
+  disableSoftSynth,
+  hasWebMidiAccess,
+  isWebMidiSupported,
+  requestWebMidiAccess,
+} from "./midiinterface"
 
-  //  if (!navigator.requestMIDIAccess) return <></>
+export type MidiDeviceOption =
+  | { type: "built-in-synth"; label: string }
+  | { type: "enable-web-midi"; label: string }
+  | { type: "web-midi-output"; label: string; deviceId: string }
+  | { type: "unavailable"; label: string }
 
-export const getMidiDeviceNames = () => {
-  const softSynthAvailable = isSoftSynthAvailable()
-  
-  // Create device list with software synth option if available
-  let deviceNames: string[]
-  if (softSynthAvailable) {
-    deviceNames = ["Software Synthesizer"]
-    if (midiOutDevices && midiOutDevices.length > 0) {
-      deviceNames.push(...midiOutDevices.map(device => device.name || "Unknown Device"))
+export const getMidiDeviceOptions = (): MidiDeviceOption[] => {
+  const options: MidiDeviceOption[] = []
+
+  if (isSoftSynthAvailable())
+    options.push({ label: "Apple2TS Built-in Synthesizer", type: "built-in-synth" })
+
+  if (hasWebMidiAccess()) {
+    if (midiOutDevices.length > 0) {
+      options.push(...midiOutDevices.map((device) => ({
+        label: device.name || "Unknown MIDI Output",
+        type: "web-midi-output" as const,
+        deviceId: device.id,
+      })))
+    } else {
+      options.push({ label: "No External MIDI Outputs", type: "unavailable" })
     }
-  } else {
-    deviceNames = midiOutDevices && midiOutDevices.length > 0 
-      ? midiOutDevices.map(device => device.name || "Unknown Device")
-      : ["No MIDI Devices"]
+  } else if (isWebMidiSupported()) {
+    options.push({ label: "Enable External MIDI…", type: "enable-web-midi" })
   }
-  return deviceNames
+
+  if (options.length === 0)
+    options.push({ label: "No MIDI Devices", type: "unavailable" })
+
+  return options
 }
 
-export const handleMidiDeviceSelect = (index: number) => {
-  const softSynthAvailable = isSoftSynthAvailable()
-  if (softSynthAvailable && index === 0) {
-    // Software synth selected
-    enableSoftSynth()
-    setMidiOutIndex(-1) // Disable hardware MIDI
-  } else {
-    // Hardware device selected
-    disableSoftSynth()
-    const hardwareIndex = softSynthAvailable ? index - 1 : index
-    setMidiOutIndex(hardwareIndex)
+export const handleMidiDeviceSelect = async (option: MidiDeviceOption) => {
+  switch (option.type) {
+    case "built-in-synth":
+      enableSoftSynth()
+      break
+
+    case "enable-web-midi":
+      if (await requestWebMidiAccess() && midiOutDevices.length > 0) {
+        const currentIndex = getMidiOutIndex()
+        if (currentIndex < 0 || currentIndex >= midiOutDevices.length)
+          setMidiOutIndex(0)
+        disableSoftSynth()
+      }
+      break
+
+    case "web-midi-output":
+    {
+      const deviceIndex = midiOutDevices.findIndex((device) => device.id === option.deviceId)
+      if (deviceIndex === -1) {
+        console.warn(`MIDI output "${option.label}" is no longer available; selection unchanged.`)
+        break
+      }
+      disableSoftSynth()
+      setMidiOutIndex(deviceIndex)
+      break
+    }
+
+    case "unavailable":
+      break
   }
 }
 
-export const getMidiCurrentIndex = () => {
-  const softSynthAvailable = isSoftSynthAvailable()
-  const softSynthActive = isSoftSynthEnabled()
-  if (softSynthActive && softSynthAvailable) {
-    return 0 // Software synth is first in list
-  }
-  const hwIndex = getMidiOutIndex()
-  return softSynthAvailable ? hwIndex + 1 : hwIndex
-}
+export const isMidiDeviceSelected = (option: MidiDeviceOption) => {
+  if (option.type === "built-in-synth")
+    return isSoftSynthEnabled() && isSoftSynthAvailable()
 
+  if (option.type === "web-midi-output")
+    return !isSoftSynthEnabled() &&
+      midiOutDevices[getMidiOutIndex()]?.id === option.deviceId
+
+  return false
+}


### PR DESCRIPTION
## Summary

- Replace the eager Web MIDI access introduced in [PR #38](https://github.com/ct6502/apple2ts/pull/38) with a lazy, user-initiated flow that requests browser permission only after **Enable External MIDI…** is selected.
- Keep the Apple2TS built-in synthesizer as the default without triggering Chrome's MIDI approval prompt at startup.
- Group Mockingboard and MIDI choices and list browser-provided outputs after approval.
- Track outputs by Web MIDI ID, preserve selections across device-list changes, and return to the built-in synthesizer if the selected output disappears.
- Add focused regression tests and concise MIDI testing documentation.

## Context

Web MIDI support was introduced in [PR #38](https://github.com/ct6502/apple2ts/pull/38), including a `requestMIDIAccess()` call during module loading. Chrome now gates Web MIDI behind explicit permission, which caused Apple2TS to display an unnecessary MIDI approval prompt at startup.

This change preserves the original external MIDI functionality while moving the browser permission request behind an explicit user action.

## Validation

- `npm test -- --runInBand` — 360 tests passed
- `npm run lint`
- `npm run build`
- Chrome: verified allow, deny, persistent block, reload, output switching, no-output state, and live disconnection
- macOS IAC Driver: verified multiple virtual outputs and disconnect fallback
- Ultima V Passport MIDI: verified output through an IAC bus to Signal
- Safari: verified that unsupported external MIDI controls are omitted without a permission prompt
