### PR TITLE
Migrate to unified ESLint Stylistic plugin

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,7 +3,7 @@ import pluginJs from "@eslint/js"
 import tseslint from "typescript-eslint"
 import pluginReact from "eslint-plugin-react"
 import reactHooks from "eslint-plugin-react-hooks"
-import stylisticJs from "@stylistic/eslint-plugin-js"
+import stylistic from "@stylistic/eslint-plugin"
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
@@ -15,7 +15,7 @@ export default [
     files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"],
     plugins: {
       "react-hooks": reactHooks,
-      "@stylistic/js": stylisticJs,
+      "@stylistic": stylistic,
     },
     languageOptions: { globals: globals.browser },
     rules: {
@@ -24,8 +24,8 @@ export default [
       // every JSX file. Turn off warnings so it doesn't complain.
       "react/react-in-jsx-scope": "off", // Disable rule that requires React to be in scope
       "react/jsx-uses-react": "off", // Disable rule that checks for React usage in JSX
-      "@stylistic/js/quotes": ["error", "double"],
-      "@stylistic/js/semi": ["error", "never"],
+      "@stylistic/quotes": ["error", "double"],
+      "@stylistic/semi": ["error", "never"],
     },
     settings: {
       react: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.34.0",
-        "@stylistic/eslint-plugin-js": "^4.4.1",
+        "@stylistic/eslint-plugin": "^5.10.0",
         "@types/audioworklet": "^0.0.100",
         "@types/gapi.client.drive-v3": "^0.0.5",
         "@types/google.accounts": "^0.0.18",
@@ -2016,21 +2016,38 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
-    "node_modules/@stylistic/eslint-plugin-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-4.4.1.tgz",
-      "integrity": "sha512-eLisyHvx7Sel8vcFZOEwDEBGmYsYM1SqDn81BWgmbqEXfXRf8oe6Rwp+ryM/8odNjlxtaaxp0Ihmt86CnLAxKg==",
+    "node_modules/@stylistic/eslint-plugin": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.10.0.tgz",
+      "integrity": "sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0"
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/types": "^8.56.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "estraverse": "^5.3.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "peerDependencies": {
-        "eslint": ">=9.0.0"
+        "eslint": "^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@swc/core": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.34.0",
-    "@stylistic/eslint-plugin-js": "^4.4.1",
+    "@stylistic/eslint-plugin": "^5.10.0",
     "@types/audioworklet": "^0.0.100",
     "@types/gapi.client.drive-v3": "^0.0.5",
     "@types/google.accounts": "^0.0.18",

--- a/src/common/custom.d.ts
+++ b/src/common/custom.d.ts
@@ -2,23 +2,23 @@ declare module "list-react-files"
 
 declare module "*.png" {
    const value: string
-   export = value;
+   export = value
 }
 declare module "*.mp3" {
    const value: string
-   export = value;
+   export = value
 }
 declare module "*.woz" {
    const value: string
-   export = value;
+   export = value
 }
 declare module "*.po" {
   const value: string
-  export = value;
+  export = value
 }
 declare module "*.hdv" {
   const value: string
-  export = value;
+  export = value
 }
 
 type MessagePayload = object | number | string | boolean | EmuGamepad[] | null
@@ -278,7 +278,7 @@ type GamePadActuatorEffect = {
 
 type KeyMap = {
   [key: string]: string;
-};
+}
 
 type GameLibraryItem = {
   address: number,


### PR DESCRIPTION
## Summary

- Replace the deprecated JavaScript-only Stylistic plugin with the maintained unified plugin.
- Preserve the existing double-quote and no-semicolon policy across JavaScript and TypeScript.
- Apply six newly detected semicolon fixes in TypeScript declarations.
- Refresh the package lockfile for the dependency change.

The unified plugin supports JavaScript, TypeScript, and JSX and is the migration path recommended by ESLint Stylistic.

Migration guide: https://eslint.style/guide/migration

## Testing

- npm ci
- npm run lint
- npm test -- --runInBand — 353 tests passed
- npm run build
- git diff --check