### PR TITLE
Skip GitHub Pages deployment in forks

### DIFF
--- a/.github/workflows/main-build-deploy.yml
+++ b/.github/workflows/main-build-deploy.yml
@@ -43,10 +43,10 @@ jobs:
     - run: npm run lint
     - run: npm run build
     - run: npm test
-    # set the correct git username/email for authentication
-    - run: git config --global user.email $MY_EMAIL
-    - run: git config --global user.name "$MY_NAME"
-    # authenticate with GitHub so we can do subsequent git operations
-    - run: git remote set-url origin https://$MY_USERNAME:${{ secrets.GH_SECRET }}@github.com/ct6502/apple2ts.git
-    # push the build (within the dist directory) to the gh-pages branch
-    - run: npm run deploy
+    - name: Deploy GitHub Pages (canonical repository only)
+      if: github.repository == 'ct6502/apple2ts'
+      run: |
+        git config --global user.email "$MY_EMAIL"
+        git config --global user.name "$MY_NAME"
+        git remote set-url origin https://$MY_USERNAME:${{ secrets.GH_SECRET }}@github.com/ct6502/apple2ts.git
+        npm run deploy


### PR DESCRIPTION
## Summary

- keep install, lint, build, and tests active on fork main pushes
- group Pages setup and deployment behind a canonical-repository check
- avoid attempts to use the maintainer-only deployment secret from forks

## Verification

- parsed the updated workflow as YAML
- ran Git diff whitespace validation
- confirmed the triggering fork run passed lint, build, and all 360 tests before failing only at deployment