### PR TITLE
Preserve more GitHub Actions history

### DIFF
--- a/.github/workflows/main-build-deploy.yml
+++ b/.github/workflows/main-build-deploy.yml
@@ -8,19 +8,6 @@ on:
     branches: [ main ]
 
 jobs:
-  # Cleanup old workflow runs (keep only last 3)
-  cleanup:
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
-    steps:
-      - name: Delete old workflow runs
-        uses: Mattraks/delete-workflow-runs@v2
-        with:
-          token: ${{ github.token }}
-          repository: ${{ github.repository }}
-          retain_days: 0
-          keep_minimum_runs: 3
-
   build:
     env:
       MY_EMAIL: 5461379+ct6502@users.noreply.github.com

--- a/.github/workflows/pull-request-build-only.yml
+++ b/.github/workflows/pull-request-build-only.yml
@@ -8,19 +8,6 @@ on:
     branches: [ main ]
 
 jobs:
-  # Cleanup old workflow runs (keep only last 3)
-  cleanup:
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
-    steps:
-      - name: Delete old workflow runs
-        uses: Mattraks/delete-workflow-runs@v2
-        with:
-          token: ${{ github.token }}
-          repository: ${{ github.repository }}
-          retain_days: 0
-          keep_minimum_runs: 3
-
   build:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
## Summary

- Remove an inapplicable PR cleanup job so successful checks no longer include a skipped result.
- Preserve more CI history by removing the matching per-push cleanup job from the main workflow.
- Continue relying on GitHub's configured retention policy for logs and artifacts.

## Why

[PR #254](https://github.com/ct6502/apple2ts/pull/254) brought this configuration to attention by displaying a harmless skipped cleanup check. Its condition cannot match a pull-request ref, so removing it reduces noise in the PR checks.

The existing main-branch cleanup job deletes older workflow runs, retaining only three per workflow. Removing that job provides more lookback when investigating CI failures while GitHub continues managing log and artifact retention.

## Verification

- Parsed both workflow files as YAML.
- Ran `git diff --check`.
- Confirmed the existing build, test, and deployment jobs are unchanged.
