### PR TITLE
Fix partial screen freezing at slow CPU speeds

### DIFF
--- a/src/worker/memory.test.ts
+++ b/src/worker/memory.test.ts
@@ -1,10 +1,36 @@
-import { setRamWorks, memGet, memSet, memory, memoryReset, memorySetForTests, setSlotDriver, memGetC000 } from "./memory"
+import { setRamWorks, memGet, memSet, memory, memoryReset, memorySetForTests, setSlotDriver, memGetC000, exportMemoryToHiresLine, getHires, publishHiresFrame } from "./memory"
 import { RamWorksMemoryStart } from "../common/utility"
 import { setIsTesting } from "./worker2main"
 import { getApple2State, setApple2State } from "./save_restore"
 import { SWITCHES } from "./softswitches"
 
 type ExpectValue = (i: number) => void
+
+test("HGR display changes only when a completed frame is published", () => {
+  const oldText = SWITCHES.TEXT.isSet
+  const oldHires = SWITCHES.HIRES.isSet
+  const oldPage2 = SWITCHES.PAGE2.isSet
+  memoryReset()
+  SWITCHES.TEXT.isSet = false
+  SWITCHES.HIRES.isSet = true
+  SWITCHES.PAGE2.isSet = false
+
+  memory[0x2000] = 0x11
+  exportMemoryToHiresLine(0)
+  publishHiresFrame()
+  expect(getHires()[0]).toEqual(0x11)
+
+  memory[0x2000] = 0x22
+  exportMemoryToHiresLine(0)
+  expect(getHires()[0]).toEqual(0x11)
+
+  publishHiresFrame()
+  expect(getHires()[0]).toEqual(0x22)
+
+  SWITCHES.TEXT.isSet = oldText
+  SWITCHES.HIRES.isSet = oldHires
+  SWITCHES.PAGE2.isSet = oldPage2
+})
 
 const doWriteIndexToMemory = (offset: number, start: number, end: number) => {
   for (let i = start; i <= end; i++) {

--- a/src/worker/memory.ts
+++ b/src/worker/memory.ts
@@ -613,6 +613,10 @@ const hiResSingle = new Uint8Array(40 * 192)
 const hiResDouble = new Uint8Array(80 * 192)
 let hiResCurrent = hiResSingle
 let hiResLines = 192
+const hiResPublishedSingle = new Uint8Array(hiResSingle.length)
+const hiResPublishedDouble = new Uint8Array(hiResDouble.length)
+let hiResPublished = hiResPublishedSingle
+let hiResPublishedLines = 192
 
 export const exportMemoryToHiresLine = (line: number) => {
   const doubleRes = SWITCHES.DHIRES.isSet && SWITCHES.COLUMN80.isSet
@@ -642,11 +646,22 @@ export const exportMemoryToHiresLine = (line: number) => {
   }
 }
 
+export const publishHiresFrame = () => {
+  if (hiResCurrent === hiResDouble) {
+    hiResPublishedDouble.set(hiResDouble)
+    hiResPublished = hiResPublishedDouble
+  } else {
+    hiResPublishedSingle.set(hiResSingle)
+    hiResPublished = hiResPublishedSingle
+  }
+  hiResPublishedLines = hiResLines
+}
+
 export const getHires = () => {
   if (SWITCHES.TEXT.isSet || !SWITCHES.HIRES.isSet) {
     return new Uint8Array()
   }
-  return (hiResLines === 192) ? hiResCurrent : hiResCurrent.slice(0, 40 * hiResLines)
+  return (hiResPublishedLines === 192) ? hiResPublished : hiResPublished.slice(0, 40 * hiResPublishedLines)
 }
 
 export const getDataBlock = (addr: number) => {
@@ -688,4 +703,3 @@ export const getMemoryDump = () => {
   }
   return dump
 }
-

--- a/src/worker/motherboard.test.ts
+++ b/src/worker/motherboard.test.ts
@@ -3,6 +3,7 @@ import { memory, updateAddressTables } from "./memory"
 import { s6502, setPC } from "./instructions"
 import { TEST_DEBUG, TEST_GRAPHICS } from "../common/utility"
 import { parseAssembly } from "./utility/assembler"
+import { advanceVideoByCpuDelta, createVideoScanout, CYCLES_PER_FRAME, VBL_CYCLES, VideoTiming, VISIBLE_SCANLINES } from "./video_timing"
 
 // Make sure we don't accidentally leave debug mode on.
 test("debugMode", () => {
@@ -18,4 +19,103 @@ test("processInstruction", () => {
   processInstruction()
   expect(s6502.PC).toEqual(0x2002)
   expect(s6502.Accum).toEqual(0xC0)
+})
+
+const runVideoChunks = (chunkCycles: number, chunkCount: number) => {
+  const scanlines: number[] = []
+  let completedFrames = 0
+  const timing = new VideoTiming({
+    setVbl: () => undefined,
+    exportScanline: (line) => scanlines.push(line),
+    completeFrame: () => completedFrames++,
+  })
+
+  for (let chunk = 0; chunk < chunkCount; chunk++) {
+    for (let cycle = 0; cycle < chunkCycles; cycle++) {
+      timing.advance(1)
+    }
+  }
+
+  return { scanlines, completedFrames }
+}
+
+test("0.5 MHz chunks complete one video frame", () => {
+  const result = runVideoChunks(CYCLES_PER_FRAME / 2, 2)
+  expect(result.scanlines).toEqual(Array.from({length: VISIBLE_SCANLINES}, (_, line) => line))
+  expect(result.completedFrames).toEqual(1)
+})
+
+test("0.1 MHz chunks complete one video frame", () => {
+  const result = runVideoChunks(CYCLES_PER_FRAME / 10, 10)
+  expect(result.scanlines).toEqual(Array.from({length: VISIBLE_SCANLINES}, (_, line) => line))
+  expect(result.completedFrames).toEqual(1)
+})
+
+test("1 MHz chunk completes one video frame", () => {
+  const result = runVideoChunks(CYCLES_PER_FRAME, 1)
+  expect(result.scanlines).toEqual(Array.from({length: VISIBLE_SCANLINES}, (_, line) => line))
+  expect(result.completedFrames).toEqual(1)
+})
+
+test("2 MHz chunk completes two video frames", () => {
+  const result = runVideoChunks(CYCLES_PER_FRAME * 2, 1)
+  const frame = Array.from({length: VISIBLE_SCANLINES}, (_, line) => line)
+  expect(result.scanlines).toEqual([...frame, ...frame])
+  expect(result.completedFrames).toEqual(2)
+})
+
+test("instruction overshoot does not contaminate the completed frame", () => {
+  let lineZeroExports = 0
+  let workingFrame = 0
+  let publishedFrame = 0
+  const scanout = createVideoScanout({
+    setVbl: () => undefined,
+    exportScanline: (line) => {
+      if (line === 0) workingFrame = ++lineZeroExports
+    },
+    publishFrame: () => {
+      publishedFrame = workingFrame
+    },
+  })
+
+  scanout.advance(CYCLES_PER_FRAME + VBL_CYCLES)
+
+  expect(workingFrame).toEqual(2)
+  expect(publishedFrame).toEqual(1)
+})
+
+test("video advances by actual CPU cycle-count delta", () => {
+  const advance = jest.fn()
+
+  expect(advanceVideoByCpuDelta({advance}, 100, 112)).toEqual(12)
+  expect(advance).toHaveBeenCalledWith(12)
+})
+
+test("video synchronization follows exact VBL boundaries", () => {
+  const vbl: boolean[] = []
+  const timing = new VideoTiming({
+    setVbl: (active) => vbl.push(active),
+    exportScanline: () => undefined,
+    completeFrame: () => undefined,
+  })
+
+  timing.synchronize(VBL_CYCLES - 1)
+  timing.synchronize(VBL_CYCLES)
+  timing.synchronize(CYCLES_PER_FRAME)
+
+  expect(vbl).toEqual([true, false, true])
+})
+
+test("video synchronization resumes after the restored scanline", () => {
+  const scanlines: number[] = []
+  const timing = new VideoTiming({
+    setVbl: () => undefined,
+    exportScanline: (line) => scanlines.push(line),
+    completeFrame: () => undefined,
+  })
+
+  timing.synchronize(VBL_CYCLES + 10 * 65)
+  timing.advance(65)
+
+  expect(scanlines).toEqual([11])
 })

--- a/src/worker/motherboard.ts
+++ b/src/worker/motherboard.ts
@@ -18,6 +18,7 @@ import { memory, memGet, getTextPage, getHires, memoryReset,
   getZeroPage,
   memSet,
   exportMemoryToHiresLine,
+  publishHiresFrame,
   getDataBlock} from "./memory"
 import { setButtonState, handleGamepads } from "./devices/joystick"
 import { handleGameSetup } from "./games/game_mappings"
@@ -35,6 +36,7 @@ import { code } from "../common/assemblycode"
 import { clearTracelog, getTracelog, updateTrace } from "./tracelog"
 import { getSiriusJoyport, setSiriusJoyport } from "./devices/sirius_joyport"
 import { doSnapshot, fixSaveStates, getGoBackwardIndex, getGoForwardIndex, getTempStateIndex, getTimeTravelThumbnails } from "./save_restore"
+import { advanceVideoByCpuDelta, createVideoScanout, VISIBLE_SCANLINES } from "./video_timing"
 
 let speedMode = 0
 let cpuSpeed = 0
@@ -66,6 +68,26 @@ const endVBL = (): void => {
   SWITCHES.VBL.isSet = false
 }
 
+const videoTiming = createVideoScanout({
+  setVbl: (active) => {
+    if (active) {
+      if (!SWITCHES.VBL.isSet) startVBL()
+    } else {
+      endVBL()
+    }
+  },
+  exportScanline: exportMemoryToHiresLine,
+  publishFrame: publishHiresFrame,
+})
+
+export const synchronizeVideoTiming = (cycleCount: number) => {
+  videoTiming.synchronize(cycleCount)
+  for (let line = 0; line < VISIBLE_SCANLINES; line++) {
+    exportMemoryToHiresLine(line)
+  }
+  publishHiresFrame()
+}
+
 export const getSoftSwitches = () => {
   const softSwitches: { [name: string]: boolean } = {}
   for (const key in SWITCHES) {
@@ -80,11 +102,13 @@ export const getMachineName = () => {
 
 export const doSetState6502 = (newState: STATE6502) => {
   setState6502(newState)
+  synchronizeVideoTiming(newState.cycleCount)
   updateExternalMachineState()
 }
 
 export const doSetCycleCount = (count: number) => {
   setCycleCount(count)
+  synchronizeVideoTiming(count)
   updateExternalMachineState()
 }
 
@@ -136,6 +160,7 @@ const resetMachine = () => {
 
 export const doBoot = () => {
   setCycleCount(0)
+  videoTiming.reset()
   memoryReset()
   doSetRom(machineName)
   configureMachine()
@@ -235,6 +260,7 @@ export const doSetMemory = (addr: number, value: number) => {
   // pass our updated data to the main thread.
   if (addr >= 0x2000 && addr <= 0x5FFF && cpuRunMode === RUN_MODE.PAUSED) {
     exportMemoryToHiresLine(hiresAddressToLine(addr))
+    publishHiresFrame()
   }
   updateExternalMachineState()
 }
@@ -535,27 +561,14 @@ const doAdvance6502 = () => {
     doSetRunMode(RUN_MODE.RUNNING)
   }
   let cycleTotal = 0
-  let currentLine = -1
   if (cyclesToRun > 0) {
     cycleToRunStart = s6502.cycleCount
   }
   for (;;) {
-    const cycles = processInstruction(tracing ? updateTrace : null)
-    if (cycles < 0) break
-    cycleTotal += cycles
-    if (cycleTotal < 4550) {
-      // Return "low" for 70 scan lines out of 262 (70 * 65 cycles = 4550)
-      if (!SWITCHES.VBL.isSet) {
-        startVBL()
-      }
-    } else {
-      endVBL()
-      const line = Math.floor((cycleTotal - 4550) / 65)
-      if (line !== currentLine && line < 192) {
-        currentLine = line
-        exportMemoryToHiresLine(line)
-      }
-    }
+    const cycleCountBefore = s6502.cycleCount
+    const result = processInstruction(tracing ? updateTrace : null)
+    cycleTotal += advanceVideoByCpuDelta(videoTiming, cycleCountBefore, s6502.cycleCount)
+    if (result < 0) break
     if (cyclesToRun > 0 && (s6502.cycleCount - cycleToRunStart) >= cyclesToRun) {
       cyclesToRun = 0
       doSetRunMode(RUN_MODE.PAUSED)

--- a/src/worker/save_restore.ts
+++ b/src/worker/save_restore.ts
@@ -4,7 +4,7 @@ import { getDriveSaveState, restoreDriveSaveState } from "./devices/drivestate"
 import { handleGameSetup } from "./games/game_mappings"
 import { s6502, getStackDump, setState6502, setStackDump } from "./instructions"
 import { memory, memoryReset, RamWorksMaxBank, setRamWorks, updateAddressTables } from "./memory"
-import { configureMachine, doReset, doSetMachineName, doSetRunMode, getMachineName, getSoftSwitches, updateExternalMachineState } from "./motherboard"
+import { configureMachine, doReset, doSetMachineName, doSetRunMode, getMachineName, getSoftSwitches, synchronizeVideoTiming, updateExternalMachineState } from "./motherboard"
 import { SWITCHES } from "./softswitches"
 import { passRequestThumbnail } from "./worker2main"
 
@@ -136,6 +136,7 @@ export const setApple2State = (newState: Apple2SaveState, version: number) => {
     setStackDump(newState.stackDump)
   }
   updateAddressTables()
+  synchronizeVideoTiming(new6502.cycleCount)
   // Force the help text to be reset if necessary.
   handleGameSetup(true)
 }

--- a/src/worker/video_timing.ts
+++ b/src/worker/video_timing.ts
@@ -1,0 +1,86 @@
+export const CYCLES_PER_FRAME = 17030
+export const VBL_CYCLES = 4550
+export const VISIBLE_SCANLINES = 192
+
+type VideoTimingCallbacks = {
+  setVbl: (active: boolean) => void,
+  exportScanline: (line: number) => void,
+  completeFrame: () => void,
+}
+
+type VideoScanoutCallbacks = Omit<VideoTimingCallbacks, "completeFrame"> & {
+  publishFrame: () => void,
+}
+
+export class VideoTiming {
+  private cycleInFrame = 0
+  private currentLine = -1
+  private readonly callbacks: VideoTimingCallbacks
+
+  constructor(callbacks: VideoTimingCallbacks) {
+    this.callbacks = callbacks
+  }
+
+  reset() {
+    this.cycleInFrame = 0
+    this.currentLine = -1
+  }
+
+  synchronize(cycleCount: number) {
+    this.cycleInFrame = ((cycleCount % CYCLES_PER_FRAME) + CYCLES_PER_FRAME) % CYCLES_PER_FRAME
+    this.currentLine = this.cycleInFrame < VBL_CYCLES
+      ? -1
+      : Math.min(
+        VISIBLE_SCANLINES - 1,
+        Math.floor((this.cycleInFrame - VBL_CYCLES) / 65),
+      )
+    this.callbacks.setVbl(this.cycleInFrame < VBL_CYCLES)
+  }
+
+  advance(cycles: number) {
+    let remaining = cycles
+    while (remaining > 0) {
+      const step = Math.min(remaining, CYCLES_PER_FRAME - this.cycleInFrame)
+      this.cycleInFrame += step
+      remaining -= step
+
+      if (this.cycleInFrame < VBL_CYCLES) {
+        this.callbacks.setVbl(true)
+      } else {
+        this.callbacks.setVbl(false)
+        const lastVisibleLine = Math.min(
+          VISIBLE_SCANLINES - 1,
+          Math.floor((this.cycleInFrame - VBL_CYCLES) / 65),
+        )
+        while (this.currentLine < lastVisibleLine) {
+          this.currentLine++
+          this.callbacks.exportScanline(this.currentLine)
+        }
+      }
+
+      if (this.cycleInFrame === CYCLES_PER_FRAME) {
+        this.callbacks.completeFrame()
+        this.cycleInFrame = 0
+        this.currentLine = -1
+      }
+    }
+  }
+}
+
+export const createVideoScanout = (callbacks: VideoScanoutCallbacks) => {
+  return new VideoTiming({
+    setVbl: callbacks.setVbl,
+    exportScanline: callbacks.exportScanline,
+    completeFrame: callbacks.publishFrame,
+  })
+}
+
+export const advanceVideoByCpuDelta = (
+  timing: Pick<VideoTiming, "advance">,
+  cycleCountBefore: number,
+  cycleCountAfter: number,
+) => {
+  const elapsedCycles = cycleCountAfter - cycleCountBefore
+  if (elapsedCycles > 0) timing.advance(elapsedCycles)
+  return Math.max(0, elapsedCycles)
+}


### PR DESCRIPTION
## Summary

- keep raster scanning continuous at CPU speeds below 1 MHz, preventing part of the display from freezing
- publish only completed HGR and DHGR frames, including when an instruction crosses a frame boundary
- resynchronize video timing after CPU cycle state is restored or rewound

## Verification

- added regression coverage for slow-speed raster progress, frame-boundary overshoot, and timing resynchronization
- `npm test -- --runInBand` — 369 tests passed
- `npm run lint`
- `npm run build`
- manually reviewed Cinnaroids at 0.1 MHz, 0.5 MHz, and normal speed
