### PR TITLE
Fix raster updates at slow CPU speeds

### DIFF
--- a/src/worker/motherboard.test.ts
+++ b/src/worker/motherboard.test.ts
@@ -1,8 +1,11 @@
 import { processInstruction } from "./cpu6502"
-import { memory, updateAddressTables } from "./memory"
+import { getHires, memory, updateAddressTables } from "./memory"
 import { s6502, setPC } from "./instructions"
-import { TEST_DEBUG, TEST_GRAPHICS } from "../common/utility"
+import { hiresLineToAddress, RUN_MODE, TEST_DEBUG, TEST_GRAPHICS } from "../common/utility"
 import { parseAssembly } from "./utility/assembler"
+import { doSetCycleCount, doSetRunMode, doSetSpeedMode } from "./motherboard"
+import { SWITCHES } from "./softswitches"
+import { setIsTesting } from "./worker2main"
 
 // Make sure we don't accidentally leave debug mode on.
 test("debugMode", () => {
@@ -18,4 +21,40 @@ test("processInstruction", () => {
   processInstruction()
   expect(s6502.PC).toEqual(0x2002)
   expect(s6502.Accum).toEqual(0xC0)
+})
+
+test("slow CPU refresh reaches the bottom HGR scanline", () => {
+  jest.useFakeTimers()
+  setIsTesting()
+  const oldText = SWITCHES.TEXT.isSet
+  const oldHires = SWITCHES.HIRES.isSet
+  const oldPage2 = SWITCHES.PAGE2.isSet
+
+  try {
+    SWITCHES.TEXT.isSet = false
+    SWITCHES.HIRES.isSet = true
+    SWITCHES.PAGE2.isSet = false
+    memory[hiresLineToAddress(0x2000, 191)] = 0x5A
+    memory.set([0x4C, 0x00, 0x08], 0x0800) // JMP $0800
+    updateAddressTables()
+    setPC(0x0800)
+    doSetCycleCount(0)
+    doSetSpeedMode(-2)
+    doSetRunMode(RUN_MODE.RUNNING)
+
+    // The first refresh runs immediately; nine timers complete one frame.
+    for (let refresh = 1; refresh < 10; refresh++) {
+      jest.advanceTimersToNextTimer()
+    }
+
+    expect(getHires()[40 * 191]).toEqual(0x5A)
+    expect(SWITCHES.VBL.isSet).toEqual(true)
+  } finally {
+    doSetRunMode(RUN_MODE.PAUSED)
+    SWITCHES.TEXT.isSet = oldText
+    SWITCHES.HIRES.isSet = oldHires
+    SWITCHES.PAGE2.isSet = oldPage2
+    jest.clearAllTimers()
+    jest.useRealTimers()
+  }
 })

--- a/src/worker/motherboard.ts
+++ b/src/worker/motherboard.ts
@@ -543,14 +543,15 @@ const doAdvance6502 = () => {
     const cycles = processInstruction(tracing ? updateTrace : null)
     if (cycles < 0) break
     cycleTotal += cycles
-    if (cycleTotal < 4550) {
+    const cycleInFrame = s6502.cycleCount % 17030
+    if (cycleInFrame < 4550) {
       // Return "low" for 70 scan lines out of 262 (70 * 65 cycles = 4550)
       if (!SWITCHES.VBL.isSet) {
         startVBL()
       }
     } else {
       endVBL()
-      const line = Math.floor((cycleTotal - 4550) / 65)
+      const line = Math.floor((cycleInFrame - 4550) / 65)
       if (line !== currentLine && line < 192) {
         currentLine = line
         exportMemoryToHiresLine(line)


### PR DESCRIPTION
## Summary

- Calculate the current video frame position from the absolute CPU cycle count.
- Let sub-frame CPU refresh budgets progress through all 192 raster lines.
- Add a regression test that reaches the bottom HGR scanline at 0.1× speed.

This replaces the implementation in #257 with the smaller approach discussed there.

## Testing

- `npm test -- --runInBand src/worker/motherboard.test.ts`
- `npm test -- --runInBand`
- `npm run lint`
- `npm run build`
