### PR TITLE
fix: Fix Guided Tour next button click navigation and focus

### DIFF
--- a/src/ui/tours/runtour.tsx
+++ b/src/ui/tours/runtour.tsx
@@ -20,11 +20,19 @@ const RunTour = () => {
       if (completed) return
     }
     console.log(`handleJoyrideCallback action=${data.action} type=${data.type} index=${data.index} ti=${tourIndex}`)
+
     if (data.type === EVENTS.STEP_AFTER) {
-      // Update state to advance the tour
-      setTourIndex(data.index + (data.action === ACTIONS.PREV ? -1 : 1))
+      if (data.action === ACTIONS.PREV) {
+        setTourIndex(Math.max(0, data.index - 1))
+      } else {
+        setTourIndex(data.index + 1)
+      }
+    } else if (data.type === EVENTS.TARGET_NOT_FOUND) {
+      console.warn(`Joyride target not found for step index ${data.index}, advancing...`)
+      setTourIndex(data.index + 1)
     }
-    if (data.type === EVENTS.TOUR_END || data.action === ACTIONS.SKIP || data.action === ACTIONS.CLOSE) {
+
+    if (data.type === EVENTS.TOUR_END || data.action === ACTIONS.SKIP || data.action === ACTIONS.CLOSE || data.status === "finished" || data.status === "skipped") {
       setRunTour("")
       setTourIndex(0)
       // If our URL contains the "tour" parameter, be sure to turn it off
@@ -89,8 +97,7 @@ const RunTour = () => {
     <span>
       {(tour.length > 0) &&
         <div className="modal-overlay"
-          style={{backgroundColor: "inherit"}}
-          tabIndex={0} // Make the div focusable
+          style={{backgroundColor: "inherit", pointerEvents: "none"}}
         >
         <Joyride
           onEvent={handleJoyrideCallback}


### PR DESCRIPTION
Hi Chris,

This PR fixes a minor interaction issue with the Guided Tour navigation where clicking the "Next (x of 8)" button in the Joyride tooltip with a mouse did not advance to the next step.

### Background / Context:
Back in July 2026 (commit `b4d6b2b4`), when `react-joyride` was updated to v3 and a full-screen `<div className="modal-overlay" tabIndex={0}>` wrapper was added in `runtour.tsx`, the `tabIndex={0}` on the outer fixed overlay began capturing mouse focus upon click, preventing click events from cleanly reaching the inner Joyride tooltip buttons.

### Key Fixes:
1. **Pointer Events & Focus**: Removed `tabIndex={0}` and added `pointerEvents: "none"` to `.modal-overlay` in `runtour.tsx` so mouse clicks and focus pass through cleanly to the Joyride tooltip buttons.
2. **Target Not Found Fallback**: Added a `TARGET_NOT_FOUND` event handler so that if a step target element is not immediately rendered in the DOM, the tour automatically advances to the next step instead of getting stuck.

Tested and verified that step navigation (1 of 8 ➔ 2 of 8 ➔ ... ➔ 8 of 8) works smoothly for both mouse clicks and keyboard Enter!

