### PR TITLE
feat(debugger): add contextual soft-switch tooltips

### DIFF
--- a/docs/reviews/disassembly-tooltips-apple2e.md
+++ b/docs/reviews/disassembly-tooltips-apple2e.md
@@ -1,71 +1,71 @@
 # Apple IIe disassembly tooltip review
 
-Each row is a concrete rendered tooltip. Adjacent addresses with the same behavior share one range. Blue code spans mark only runtime-dependent text; they are not part of the actual tooltip.
+Each row records the semantic-tooltip outcome. Adjacent addresses with the same behavior share one range. _No semantic tooltip_ means that the address is known but the operation intentionally displays no semantic or generic value tooltip. Blue code spans mark only runtime-dependent text; they are not part of the actual tooltip.
 The Value column uses representative runtime values only to make conditional tooltip text concrete; it does not imply a particular source register, preceding instruction, or machine state.
 
 | Range | Access | Value | Tooltip |
 |---|---|---|---|
-| $C000–$C00F | Read | $5D | Keyboard = "`]`"; Strobe is `CLEAR` (bit 7 = `0`) |
-| $C000–$C00F | Read | $DD | Keyboard = "`]`"; Strobe is `SET` (bit 7 = `1`) |
-| $C000 | Write |  | Disable PAGE2 display-memory banking |
-| $C001 | Write |  | Enable PAGE2 display-memory banking |
+| $C000–$C00F | Read | $5D | Keyboard: "`]`"<br>Keyboard strobe: `CLEAR` (MSB = `0`) |
+| $C000–$C00F | Read | $DD | Keyboard: "`]`"<br>Keyboard strobe: `SET` (MSB = `1`) |
+| $C000 | Write |  | Make PAGE2 select display page 1 or 2 |
+| $C001 | Write |  | Make PAGE2 select main or auxiliary display memory |
 | $C002 | Write |  | Select main memory for reads |
 | $C003 | Write |  | Select auxiliary memory for reads |
 | $C004 | Write |  | Select main memory for writes |
 | $C005 | Write |  | Select auxiliary memory for writes |
 | $C006 | Write |  | Select slot ROM for $C100-$CFFF |
 | $C007 | Write |  | Select internal ROM for $C100-$CFFF |
-| $C008 | Write |  | Select main zero page and stack |
-| $C009 | Write |  | Select auxiliary zero page and stack |
+| $C008 | Write |  | Select main zero page, stack, and bank-switched RAM |
+| $C009 | Write |  | Select auxiliary zero page, stack, and bank-switched RAM |
 | $C00A | Write |  | Select internal ROM for $C300-$C3FF |
-| $C00B | Write |  | Select slot 3 ROM |
-| $C00C | Write |  | Select 40-column display |
-| $C00D | Write |  | Select 80-column display |
+| $C00B | Write |  | Select slot ROM for $C300-$C3FF |
+| $C00C | Write |  | Set display width to 40 columns |
+| $C00D | Write |  | Set display width to 80 columns |
 | $C00E | Write |  | Select primary character set |
 | $C00F | Write |  | Select alternate character set |
-| $C010 | Read | $00 | Any Key Down = `NO` (bit 7 = `0`); Clear keyboard strobe |
-| $C010 | Read | $80 | Any Key Down = `YES` (bit 7 = `1`); Clear keyboard strobe |
+| $C010 | Read | $00 | Any-key-down flag: `CLEAR` (MSB = `0`)<br>Clear keyboard strobe |
+| $C010 | Read | $80 | Any-key-down flag: `SET` (MSB = `1`)<br>Clear keyboard strobe |
 | $C010–$C01F | Write |  | Clear keyboard strobe |
-| $C011 | Read | $00 | Language Card Bank = `1` (bit 7 = `0`) |
-| $C011 | Read | $80 | Language Card Bank = `2` (bit 7 = `1`) |
-| $C012 | Read | $00 | Language Card Read Source = `ROM` (bit 7 = `0`) |
-| $C012 | Read | $80 | Language Card Read Source = `RAM` (bit 7 = `1`) |
-| $C013 | Read | $00 | Auxiliary-Memory Reads = `OFF` (bit 7 = `0`) |
-| $C013 | Read | $80 | Auxiliary-Memory Reads = `ON` (bit 7 = `1`) |
-| $C014 | Read | $00 | Auxiliary-Memory Writes = `OFF` (bit 7 = `0`) |
-| $C014 | Read | $80 | Auxiliary-Memory Writes = `ON` (bit 7 = `1`) |
-| $C015 | Read | $00 | Internal $Cx ROM = `OFF` (bit 7 = `0`) |
-| $C015 | Read | $80 | Internal $Cx ROM = `ON` (bit 7 = `1`) |
-| $C016 | Read | $00 | Auxiliary Zero Page and Stack = `OFF` (bit 7 = `0`) |
-| $C016 | Read | $80 | Auxiliary Zero Page and Stack = `ON` (bit 7 = `1`) |
-| $C017 | Read | $00 | Slot 3 ROM = `OFF` (bit 7 = `0`) |
-| $C017 | Read | $80 | Slot 3 ROM = `ON` (bit 7 = `1`) |
-| $C018 | Read | $00 | PAGE2 Display-Memory Banking = `OFF` (bit 7 = `0`) |
-| $C018 | Read | $80 | PAGE2 Display-Memory Banking = `ON` (bit 7 = `1`) |
-| $C019 | Read | $00 | Vertical Blank = `ACTIVE` (bit 7 = `0`) |
-| $C019 | Read | $80 | Vertical Blank = `INACTIVE` (bit 7 = `1`) |
-| $C01A | Read | $00 | Text Mode = `OFF` (bit 7 = `0`) |
-| $C01A | Read | $80 | Text Mode = `ON` (bit 7 = `1`) |
-| $C01B | Read | $00 | Mixed Display = `OFF` (bit 7 = `0`) |
-| $C01B | Read | $80 | Mixed Display = `ON` (bit 7 = `1`) |
-| $C01C | Read | $00 | Display Page = `1` (bit 7 = `0`) |
-| $C01C | Read | $80 | Display Page = `2` (bit 7 = `1`) |
-| $C01D | Read | $00 | Hi-Res Mode = `OFF` (bit 7 = `0`) |
-| $C01D | Read | $80 | Hi-Res Mode = `ON` (bit 7 = `1`) |
-| $C01E | Read | $00 | Alternate Character Set = `OFF` (bit 7 = `0`) |
-| $C01E | Read | $80 | Alternate Character Set = `ON` (bit 7 = `1`) |
-| $C01F | Read | $00 | 80-Column Display = `OFF` (bit 7 = `0`) |
-| $C01F | Read | $80 | 80-Column Display = `ON` (bit 7 = `1`) |
+| $C011 | Read | $00 | Language Card bank: `1` (MSB = `0`) |
+| $C011 | Read | $80 | Language Card bank: `2` (MSB = `1`) |
+| $C012 | Read | $00 | Language Card read source: `ROM` (MSB = `0`) |
+| $C012 | Read | $80 | Language Card read source: `RAM` (MSB = `1`) |
+| $C013 | Read | $00 | Auxiliary-memory reads: `OFF` (MSB = `0`) |
+| $C013 | Read | $80 | Auxiliary-memory reads: `ON` (MSB = `1`) |
+| $C014 | Read | $00 | Auxiliary-memory writes: `OFF` (MSB = `0`) |
+| $C014 | Read | $80 | Auxiliary-memory writes: `ON` (MSB = `1`) |
+| $C015 | Read | $00 | Internal $Cx ROM: `OFF` (MSB = `0`) |
+| $C015 | Read | $80 | Internal $Cx ROM: `ON` (MSB = `1`) |
+| $C016 | Read | $00 | Zero page, stack, and bank-switched RAM: `MAIN` (MSB = `0`) |
+| $C016 | Read | $80 | Zero page, stack, and bank-switched RAM: `AUXILIARY` (MSB = `1`) |
+| $C017 | Read | $00 | Slot 3 ROM: `OFF` (MSB = `0`) |
+| $C017 | Read | $80 | Slot 3 ROM: `ON` (MSB = `1`) |
+| $C018 | Read | $00 | PAGE2 selects display page 1 or 2 (MSB = `0`) |
+| $C018 | Read | $80 | PAGE2 selects main or auxiliary display memory (MSB = `1`) |
+| $C019 | Read | $00 | Vertical blank: `ACTIVE` (MSB = `0`) |
+| $C019 | Read | $80 | Vertical blank: `INACTIVE` (MSB = `1`) |
+| $C01A | Read | $00 | Text mode: `OFF` (MSB = `0`) |
+| $C01A | Read | $80 | Text mode: `ON` (MSB = `1`) |
+| $C01B | Read | $00 | Mixed display: `OFF` (MSB = `0`) |
+| $C01B | Read | $80 | Mixed display: `ON` (MSB = `1`) |
+| $C01C | Read | $00 | Display-memory selection: `PAGE 1 OR MAIN` (MSB = `0`) |
+| $C01C | Read | $80 | Display-memory selection: `PAGE 2 OR AUXILIARY` (MSB = `1`) |
+| $C01D | Read | $00 | Hi-res mode: `OFF` (MSB = `0`) |
+| $C01D | Read | $80 | Hi-res mode: `ON` (MSB = `1`) |
+| $C01E | Read | $00 | Alternate character set: `OFF` (MSB = `0`) |
+| $C01E | Read | $80 | Alternate character set: `ON` (MSB = `1`) |
+| $C01F | Read | $00 | 80-column display: `OFF` (MSB = `0`) |
+| $C01F | Read | $80 | 80-column display: `ON` (MSB = `1`) |
 | $C020 | Read/write |  | Toggle cassette output |
 | $C030 | Read/write |  | Toggle speaker output |
 | $C040 | Read/write |  | Pulse game-port strobe |
-| $C04F | Read/write |  | Apple2TS emulation marker always = $CD |
+| $C04F | Read/write |  | INFO: Apple2TS emulator identifier: $CD |
 | $C050 | Read/write |  | Select graphics mode |
 | $C051 | Read/write |  | Select text mode |
 | $C052 | Read/write |  | Select full-screen display |
 | $C053 | Read/write |  | Select mixed graphics/text |
-| $C054 | Read/write |  | Select display page 1 |
-| $C055 | Read/write |  | Select display page 2 |
+| $C054 | Read/write |  | Select display page 1, or main display memory with 80STORE |
+| $C055 | Read/write |  | Select display page 2, or auxiliary display memory with 80STORE |
 | $C056 | Read/write |  | Select lo-res graphics |
 | $C057 | Read/write |  | Select hi-res graphics |
 | $C058 | Read/write |  | Disable annunciator 0 |
@@ -74,65 +74,87 @@ The Value column uses representative runtime values only to make conditional too
 | $C05B | Read/write |  | Enable annunciator 1 |
 | $C05C | Read/write |  | Disable annunciator 2 |
 | $C05D | Read/write |  | Enable annunciator 2 |
-| $C05E | Read/write |  | Disable annunciator 3; enable DHIRES |
-| $C05F | Read/write |  | Enable annunciator 3; disable DHIRES |
+| $C05E | Read/write |  | Disable annunciator 3<br>Enable DHIRES |
+| $C05F | Read/write |  | Enable annunciator 3<br>Disable DHIRES |
 | $C060 | Read |  | Sample cassette input |
-| $C061 | Read | $00 | Pushbutton 0 = `RELEASED` (bit 7 = `0`) |
-| $C061 | Read | $80 | Pushbutton 0 = `PRESSED` (bit 7 = `1`) |
-| $C062 | Read | $00 | Pushbutton 1 = `RELEASED` (bit 7 = `0`) |
-| $C062 | Read | $80 | Pushbutton 1 = `PRESSED` (bit 7 = `1`) |
-| $C063 | Read | $00 | Pushbutton 2 = `RELEASED` (bit 7 = `0`) |
-| $C063 | Read | $80 | Pushbutton 2 = `PRESSED` (bit 7 = `1`) |
-| $C064 | Read | $00 | Paddle 0 Timer = `EXPIRED` (bit 7 = `0`) |
-| $C064 | Read | $80 | Paddle 0 Timer = `ACTIVE` (bit 7 = `1`) |
-| $C065 | Read | $00 | Paddle 1 Timer = `EXPIRED` (bit 7 = `0`) |
-| $C065 | Read | $80 | Paddle 1 Timer = `ACTIVE` (bit 7 = `1`) |
-| $C066 | Read | $00 | Paddle 2 Timer = `EXPIRED` (bit 7 = `0`) |
-| $C066 | Read | $80 | Paddle 2 Timer = `ACTIVE` (bit 7 = `1`) |
-| $C067 | Read | $00 | Paddle 3 Timer = `EXPIRED` (bit 7 = `0`) |
-| $C067 | Read | $80 | Paddle 3 Timer = `ACTIVE` (bit 7 = `1`) |
+| $C060–$C06F | Write |  | _No semantic tooltip_ |
+| $C061 | Read | $00 | Pushbutton 0: `RELEASED` (MSB = `0`) |
+| $C061 | Read | $80 | Pushbutton 0: `PRESSED` (MSB = `1`) |
+| $C062 | Read | $00 | Pushbutton 1: `RELEASED` (MSB = `0`) |
+| $C062 | Read | $80 | Pushbutton 1: `PRESSED` (MSB = `1`) |
+| $C063 | Read | $00 | Pushbutton 2: `RELEASED` (MSB = `0`) |
+| $C063 | Read | $80 | Pushbutton 2: `PRESSED` (MSB = `1`) |
+| $C064 | Read | $00 | Paddle 0 timer: `EXPIRED` (MSB = `0`) |
+| $C064 | Read | $80 | Paddle 0 timer: `ACTIVE` (MSB = `1`) |
+| $C065 | Read | $00 | Paddle 1 timer: `EXPIRED` (MSB = `0`) |
+| $C065 | Read | $80 | Paddle 1 timer: `ACTIVE` (MSB = `1`) |
+| $C066 | Read | $00 | Paddle 2 timer: `EXPIRED` (MSB = `0`) |
+| $C066 | Read | $80 | Paddle 2 timer: `ACTIVE` (MSB = `1`) |
+| $C067 | Read | $00 | Paddle 3 timer: `EXPIRED` (MSB = `0`) |
+| $C067 | Read | $80 | Paddle 3 timer: `ACTIVE` (MSB = `1`) |
 | $C068 | Read |  | Sample cassette-input mirror |
-| $C069 | Read | $00 | Pushbutton 0 Mirror = `RELEASED` (bit 7 = `0`) |
-| $C069 | Read | $80 | Pushbutton 0 Mirror = `PRESSED` (bit 7 = `1`) |
-| $C06A | Read | $00 | Pushbutton 1 Mirror = `RELEASED` (bit 7 = `0`) |
-| $C06A | Read | $80 | Pushbutton 1 Mirror = `PRESSED` (bit 7 = `1`) |
-| $C06B | Read | $00 | Pushbutton 2 Mirror = `RELEASED` (bit 7 = `0`) |
-| $C06B | Read | $80 | Pushbutton 2 Mirror = `PRESSED` (bit 7 = `1`) |
-| $C06C | Read | $00 | Paddle 0 Timer Mirror = `EXPIRED` (bit 7 = `0`) |
-| $C06C | Read | $80 | Paddle 0 Timer Mirror = `ACTIVE` (bit 7 = `1`) |
-| $C06D | Read | $00 | Paddle 1 Timer Mirror = `EXPIRED` (bit 7 = `0`) |
-| $C06D | Read | $80 | Paddle 1 Timer Mirror = `ACTIVE` (bit 7 = `1`) |
-| $C06E | Read | $00 | Paddle 2 Timer Mirror = `EXPIRED` (bit 7 = `0`) |
-| $C06E | Read | $80 | Paddle 2 Timer Mirror = `ACTIVE` (bit 7 = `1`) |
-| $C06F | Read | $00 | Paddle 3 Timer Mirror = `EXPIRED` (bit 7 = `0`) |
-| $C06F | Read | $80 | Paddle 3 Timer Mirror = `ACTIVE` (bit 7 = `1`) |
+| $C069 | Read | $00 | Pushbutton 0 mirror: `RELEASED` (MSB = `0`) |
+| $C069 | Read | $80 | Pushbutton 0 mirror: `PRESSED` (MSB = `1`) |
+| $C06A | Read | $00 | Pushbutton 1 mirror: `RELEASED` (MSB = `0`) |
+| $C06A | Read | $80 | Pushbutton 1 mirror: `PRESSED` (MSB = `1`) |
+| $C06B | Read | $00 | Pushbutton 2 mirror: `RELEASED` (MSB = `0`) |
+| $C06B | Read | $80 | Pushbutton 2 mirror: `PRESSED` (MSB = `1`) |
+| $C06C | Read | $00 | Paddle 0 timer mirror: `EXPIRED` (MSB = `0`) |
+| $C06C | Read | $80 | Paddle 0 timer mirror: `ACTIVE` (MSB = `1`) |
+| $C06D | Read | $00 | Paddle 1 timer mirror: `EXPIRED` (MSB = `0`) |
+| $C06D | Read | $80 | Paddle 1 timer mirror: `ACTIVE` (MSB = `1`) |
+| $C06E | Read | $00 | Paddle 2 timer mirror: `EXPIRED` (MSB = `0`) |
+| $C06E | Read | $80 | Paddle 2 timer mirror: `ACTIVE` (MSB = `1`) |
+| $C06F | Read | $00 | Paddle 3 timer mirror: `EXPIRED` (MSB = `0`) |
+| $C06F | Read | $80 | Paddle 3 timer mirror: `ACTIVE` (MSB = `1`) |
 | $C070 | Read/write |  | Start paddle timers |
-| $C071 | Write | $03 | Select auxiliary bank $03 using Neptune addressing; start paddle timers |
-| $C073 | Write | $03 | Select auxiliary bank $03 using RamWorks addressing; start paddle timers |
-| $C074 | Read/write |  | Laser 128EX compatibility = NOT EMULATED |
-| $C080 | Read |  | Select LC bank 2; use RAM for reads; disable writes |
-| $C080 | Write |  | Select LC bank 2; use RAM for reads; reset prewrite latch |
-| $C081 | Read |  | Select LC bank 2; use ROM for reads; arm/enable writes |
-| $C081–$C082 | Write |  | Select LC bank 2; use ROM for reads; reset prewrite latch |
-| $C082 | Read |  | Select LC bank 2; use ROM for reads; disable writes |
-| $C083 | Read |  | Select LC bank 2; use RAM for reads; arm/enable writes |
-| $C083–$C084 | Write |  | Select LC bank 2; use RAM for reads; reset prewrite latch |
-| $C084 | Read |  | Select LC bank 2; use RAM for reads; disable writes |
-| $C085 | Read |  | Select LC bank 2; use ROM for reads; arm/enable writes |
-| $C085–$C086 | Write |  | Select LC bank 2; use ROM for reads; reset prewrite latch |
-| $C086 | Read |  | Select LC bank 2; use ROM for reads; disable writes |
-| $C087 | Read |  | Select LC bank 2; use RAM for reads; arm/enable writes |
-| $C087 | Write |  | Select LC bank 2; use RAM for reads; reset prewrite latch |
-| $C088 | Read |  | Select LC bank 1; use RAM for reads; disable writes |
-| $C088 | Write |  | Select LC bank 1; use RAM for reads; reset prewrite latch |
-| $C089 | Read |  | Select LC bank 1; use ROM for reads; arm/enable writes |
-| $C089–$C08A | Write |  | Select LC bank 1; use ROM for reads; reset prewrite latch |
-| $C08A | Read |  | Select LC bank 1; use ROM for reads; disable writes |
-| $C08B | Read |  | Select LC bank 1; use RAM for reads; arm/enable writes |
-| $C08B–$C08C | Write |  | Select LC bank 1; use RAM for reads; reset prewrite latch |
-| $C08C | Read |  | Select LC bank 1; use RAM for reads; disable writes |
-| $C08D | Read |  | Select LC bank 1; use ROM for reads; arm/enable writes |
-| $C08D–$C08E | Write |  | Select LC bank 1; use ROM for reads; reset prewrite latch |
-| $C08E | Read |  | Select LC bank 1; use ROM for reads; disable writes |
-| $C08F | Read |  | Select LC bank 1; use RAM for reads; arm/enable writes |
-| $C08F | Write |  | Select LC bank 1; use RAM for reads; reset prewrite latch |
+| $C071 | Read |  | Start paddle timers |
+| $C071 | Write | $03 | Start paddle timers<br>Select auxiliary expansion bank $03 using Neptune addressing |
+| $C072 | Read/write |  | Start paddle timers |
+| $C073–$C074 | Read |  | Start paddle timers |
+| $C073 | Write | $03 | Start paddle timers<br>Select auxiliary expansion bank $03 using RamWorks addressing |
+| $C074 | Write | $00 | Start paddle timers<br>TransWarp: Select configured maximum speed<br>Laser 128EX: Select 1 MHz maximum CPU speed<br>Laser 128EX: Disable automatic 1 MHz slowdown for port 7 disk access (write-once bit 5) |
+| $C074 | Write | $01 | Start paddle timers<br>TransWarp: Select 1 MHz<br>Laser 128EX: Select 1 MHz maximum CPU speed<br>Laser 128EX: Disable automatic 1 MHz slowdown for port 7 disk access (write-once bit 5) |
+| $C074 | Write | $03 | Start paddle timers<br>TransWarp: Disable acceleration until cold boot<br>Laser 128EX: Select 1 MHz maximum CPU speed<br>Laser 128EX: Disable automatic 1 MHz slowdown for port 7 disk access (write-once bit 5) |
+| $C074 | Write | $40 | Start paddle timers<br>Laser 128EX: Select 1 MHz maximum CPU speed<br>Laser 128EX: Disable automatic 1 MHz slowdown for port 7 disk access (write-once bit 5) |
+| $C074 | Write | $A0 | Start paddle timers<br>Laser 128EX: Select 2.3 MHz maximum CPU speed<br>Laser 128EX: Enable automatic 1 MHz slowdown for port 7 disk access (write-once bit 5) |
+| $C074 | Write | $C0 | Start paddle timers<br>Laser 128EX: Select 3.6 MHz maximum CPU speed<br>Laser 128EX: Disable automatic 1 MHz slowdown for port 7 disk access (write-once bit 5) |
+| $C075–$C07F | Read/write |  | Start paddle timers |
+| $C080 | Read |  | Language Card: Select bank 2<br>Language Card: Use RAM for reads<br>Language Card: Disable writes |
+| $C080 | Write |  | Language Card: Select bank 2<br>Language Card: Use RAM for reads<br>Language Card: Reset prewrite latch |
+| $C081 | Read |  | Language Card: Select bank 2<br>Language Card: Use ROM for reads<br>Language Card: Arm or enable writes |
+| $C081–$C082 | Write |  | Language Card: Select bank 2<br>Language Card: Use ROM for reads<br>Language Card: Reset prewrite latch |
+| $C082 | Read |  | Language Card: Select bank 2<br>Language Card: Use ROM for reads<br>Language Card: Disable writes |
+| $C083 | Read |  | Language Card: Select bank 2<br>Language Card: Use RAM for reads<br>Language Card: Arm or enable writes |
+| $C083–$C084 | Write |  | Language Card: Select bank 2<br>Language Card: Use RAM for reads<br>Language Card: Reset prewrite latch |
+| $C084 | Read |  | Language Card: Select bank 2<br>Language Card: Use RAM for reads<br>Language Card: Disable writes |
+| $C085 | Read |  | Language Card: Select bank 2<br>Language Card: Use ROM for reads<br>Language Card: Arm or enable writes |
+| $C085–$C086 | Write |  | Language Card: Select bank 2<br>Language Card: Use ROM for reads<br>Language Card: Reset prewrite latch |
+| $C086 | Read |  | Language Card: Select bank 2<br>Language Card: Use ROM for reads<br>Language Card: Disable writes |
+| $C087 | Read |  | Language Card: Select bank 2<br>Language Card: Use RAM for reads<br>Language Card: Arm or enable writes |
+| $C087 | Write |  | Language Card: Select bank 2<br>Language Card: Use RAM for reads<br>Language Card: Reset prewrite latch |
+| $C088 | Read |  | Language Card: Select bank 1<br>Language Card: Use RAM for reads<br>Language Card: Disable writes |
+| $C088 | Write |  | Language Card: Select bank 1<br>Language Card: Use RAM for reads<br>Language Card: Reset prewrite latch |
+| $C089 | Read |  | Language Card: Select bank 1<br>Language Card: Use ROM for reads<br>Language Card: Arm or enable writes |
+| $C089–$C08A | Write |  | Language Card: Select bank 1<br>Language Card: Use ROM for reads<br>Language Card: Reset prewrite latch |
+| $C08A | Read |  | Language Card: Select bank 1<br>Language Card: Use ROM for reads<br>Language Card: Disable writes |
+| $C08B | Read |  | Language Card: Select bank 1<br>Language Card: Use RAM for reads<br>Language Card: Arm or enable writes |
+| $C08B–$C08C | Write |  | Language Card: Select bank 1<br>Language Card: Use RAM for reads<br>Language Card: Reset prewrite latch |
+| $C08C | Read |  | Language Card: Select bank 1<br>Language Card: Use RAM for reads<br>Language Card: Disable writes |
+| $C08D | Read |  | Language Card: Select bank 1<br>Language Card: Use ROM for reads<br>Language Card: Arm or enable writes |
+| $C08D–$C08E | Write |  | Language Card: Select bank 1<br>Language Card: Use ROM for reads<br>Language Card: Reset prewrite latch |
+| $C08E | Read |  | Language Card: Select bank 1<br>Language Card: Use ROM for reads<br>Language Card: Disable writes |
+| $C08F | Read |  | Language Card: Select bank 1<br>Language Card: Use RAM for reads<br>Language Card: Arm or enable writes |
+| $C08F | Write |  | Language Card: Select bank 1<br>Language Card: Use RAM for reads<br>Language Card: Reset prewrite latch |
+
+## Instruction-sensitive cases
+
+These representative instructions exercise tooltips whose meaning or warning depends on how the instruction accesses the soft switch. Indexed and indirect examples assume that the displayed instruction is at the current PC; paused state does not reliably resolve those operands on other rows (issue #303).
+
+| Instruction | Write value | Tooltip |
+|---|---|---|
+| `INC $C030` | — | WARNING: This instruction triggers the soft switch multiple times |
+| `STA $C070,X (X = $03)` | $03 | Start paddle timers<br>WARNING: This instruction triggers the soft switch multiple times<br>Select auxiliary expansion bank $03 using RamWorks addressing |
+| `INC $C073` | UNKNOWN | Start paddle timers<br>WARNING: This instruction writes an unknown value |
+| `STA $C070,X (X = $04)` | $01 | Start paddle timers<br>WARNING: This instruction triggers the soft switch multiple times<br>TransWarp: Select 1 MHz<br>Laser 128EX: Select 1 MHz maximum CPU speed<br>Laser 128EX: Disable automatic 1 MHz slowdown for port 7 disk access (write-once bit 5) |
+| `INC $C074` | UNKNOWN | Start paddle timers<br>WARNING: This instruction writes an unknown value |

--- a/docs/reviews/disassembly-tooltips-apple2p.md
+++ b/docs/reviews/disassembly-tooltips-apple2p.md
@@ -1,18 +1,18 @@
 # Apple II+ disassembly tooltip review
 
-Each row is a concrete rendered tooltip. Adjacent addresses with the same behavior share one range. Blue code spans mark only runtime-dependent text; they are not part of the actual tooltip.
+Each row records the semantic-tooltip outcome. Adjacent addresses with the same behavior share one range. _No semantic tooltip_ means that the address is known but the operation intentionally displays no semantic or generic value tooltip. Blue code spans mark only runtime-dependent text; they are not part of the actual tooltip.
 The Value column uses representative runtime values only to make conditional tooltip text concrete; it does not imply a particular source register, preceding instruction, or machine state.
 
 | Range | Access | Value | Tooltip |
 |---|---|---|---|
-| $C000–$C00F | Read | $5D | Keyboard = "`]`"; Strobe is `CLEAR` (bit 7 = `0`) |
-| $C000–$C00F | Read | $DD | Keyboard = "`]`"; Strobe is `SET` (bit 7 = `1`) |
-| $C000–$C00F | Write |  | Write ignored on Apple II+ |
+| $C000–$C00F | Read | $5D | Keyboard: "`]`"<br>Keyboard strobe: `CLEAR` (MSB = `0`) |
+| $C000–$C00F | Read | $DD | Keyboard: "`]`"<br>Keyboard strobe: `SET` (MSB = `1`) |
+| $C000–$C00F | Write |  | INFO: This write has no effect on Apple II+ |
 | $C010–$C01F | Read/write |  | Clear keyboard strobe |
 | $C020 | Read/write |  | Toggle cassette output |
 | $C030 | Read/write |  | Toggle speaker output |
 | $C040 | Read/write |  | Pulse game-port strobe |
-| $C04F | Read/write |  | Apple2TS emulation marker always = $CD |
+| $C04F | Read/write |  | INFO: Apple2TS emulator identifier: $CD |
 | $C050 | Read/write |  | Select graphics mode |
 | $C051 | Read/write |  | Select text mode |
 | $C052 | Read/write |  | Select full-screen display |
@@ -30,60 +30,80 @@ The Value column uses representative runtime values only to make conditional too
 | $C05E | Read/write |  | Disable annunciator 3 |
 | $C05F | Read/write |  | Enable annunciator 3 |
 | $C060 | Read |  | Sample cassette input |
-| $C061 | Read | $00 | Pushbutton 0 = `RELEASED` (bit 7 = `0`) |
-| $C061 | Read | $80 | Pushbutton 0 = `PRESSED` (bit 7 = `1`) |
-| $C062 | Read | $00 | Pushbutton 1 = `RELEASED` (bit 7 = `0`) |
-| $C062 | Read | $80 | Pushbutton 1 = `PRESSED` (bit 7 = `1`) |
-| $C063 | Read | $00 | Pushbutton 2 = `RELEASED` (bit 7 = `0`) |
-| $C063 | Read | $80 | Pushbutton 2 = `PRESSED` (bit 7 = `1`) |
-| $C064 | Read | $00 | Paddle 0 Timer = `EXPIRED` (bit 7 = `0`) |
-| $C064 | Read | $80 | Paddle 0 Timer = `ACTIVE` (bit 7 = `1`) |
-| $C065 | Read | $00 | Paddle 1 Timer = `EXPIRED` (bit 7 = `0`) |
-| $C065 | Read | $80 | Paddle 1 Timer = `ACTIVE` (bit 7 = `1`) |
-| $C066 | Read | $00 | Paddle 2 Timer = `EXPIRED` (bit 7 = `0`) |
-| $C066 | Read | $80 | Paddle 2 Timer = `ACTIVE` (bit 7 = `1`) |
-| $C067 | Read | $00 | Paddle 3 Timer = `EXPIRED` (bit 7 = `0`) |
-| $C067 | Read | $80 | Paddle 3 Timer = `ACTIVE` (bit 7 = `1`) |
+| $C060–$C06F | Write |  | _No semantic tooltip_ |
+| $C061 | Read | $00 | Pushbutton 0: `RELEASED` (MSB = `0`) |
+| $C061 | Read | $80 | Pushbutton 0: `PRESSED` (MSB = `1`) |
+| $C062 | Read | $00 | Pushbutton 1: `RELEASED` (MSB = `0`) |
+| $C062 | Read | $80 | Pushbutton 1: `PRESSED` (MSB = `1`) |
+| $C063 | Read | $00 | Pushbutton 2: `RELEASED` (MSB = `0`) |
+| $C063 | Read | $80 | Pushbutton 2: `PRESSED` (MSB = `1`) |
+| $C064 | Read | $00 | Paddle 0 timer: `EXPIRED` (MSB = `0`) |
+| $C064 | Read | $80 | Paddle 0 timer: `ACTIVE` (MSB = `1`) |
+| $C065 | Read | $00 | Paddle 1 timer: `EXPIRED` (MSB = `0`) |
+| $C065 | Read | $80 | Paddle 1 timer: `ACTIVE` (MSB = `1`) |
+| $C066 | Read | $00 | Paddle 2 timer: `EXPIRED` (MSB = `0`) |
+| $C066 | Read | $80 | Paddle 2 timer: `ACTIVE` (MSB = `1`) |
+| $C067 | Read | $00 | Paddle 3 timer: `EXPIRED` (MSB = `0`) |
+| $C067 | Read | $80 | Paddle 3 timer: `ACTIVE` (MSB = `1`) |
 | $C068 | Read |  | Sample cassette-input mirror |
-| $C069 | Read | $00 | Pushbutton 0 Mirror = `RELEASED` (bit 7 = `0`) |
-| $C069 | Read | $80 | Pushbutton 0 Mirror = `PRESSED` (bit 7 = `1`) |
-| $C06A | Read | $00 | Pushbutton 1 Mirror = `RELEASED` (bit 7 = `0`) |
-| $C06A | Read | $80 | Pushbutton 1 Mirror = `PRESSED` (bit 7 = `1`) |
-| $C06B | Read | $00 | Pushbutton 2 Mirror = `RELEASED` (bit 7 = `0`) |
-| $C06B | Read | $80 | Pushbutton 2 Mirror = `PRESSED` (bit 7 = `1`) |
-| $C06C | Read | $00 | Paddle 0 Timer Mirror = `EXPIRED` (bit 7 = `0`) |
-| $C06C | Read | $80 | Paddle 0 Timer Mirror = `ACTIVE` (bit 7 = `1`) |
-| $C06D | Read | $00 | Paddle 1 Timer Mirror = `EXPIRED` (bit 7 = `0`) |
-| $C06D | Read | $80 | Paddle 1 Timer Mirror = `ACTIVE` (bit 7 = `1`) |
-| $C06E | Read | $00 | Paddle 2 Timer Mirror = `EXPIRED` (bit 7 = `0`) |
-| $C06E | Read | $80 | Paddle 2 Timer Mirror = `ACTIVE` (bit 7 = `1`) |
-| $C06F | Read | $00 | Paddle 3 Timer Mirror = `EXPIRED` (bit 7 = `0`) |
-| $C06F | Read | $80 | Paddle 3 Timer Mirror = `ACTIVE` (bit 7 = `1`) |
-| $C070 | Read/write |  | Start paddle timers |
-| $C074 | Read/write |  | Laser 128EX compatibility = NOT EMULATED |
-| $C080 | Read |  | Select LC bank 2; use RAM for reads; disable writes |
-| $C080 | Write |  | Select LC bank 2; use RAM for reads; reset prewrite latch |
-| $C081 | Read |  | Select LC bank 2; use ROM for reads; arm/enable writes |
-| $C081–$C082 | Write |  | Select LC bank 2; use ROM for reads; reset prewrite latch |
-| $C082 | Read |  | Select LC bank 2; use ROM for reads; disable writes |
-| $C083 | Read |  | Select LC bank 2; use RAM for reads; arm/enable writes |
-| $C083–$C084 | Write |  | Select LC bank 2; use RAM for reads; reset prewrite latch |
-| $C084 | Read |  | Select LC bank 2; use RAM for reads; disable writes |
-| $C085 | Read |  | Select LC bank 2; use ROM for reads; arm/enable writes |
-| $C085–$C086 | Write |  | Select LC bank 2; use ROM for reads; reset prewrite latch |
-| $C086 | Read |  | Select LC bank 2; use ROM for reads; disable writes |
-| $C087 | Read |  | Select LC bank 2; use RAM for reads; arm/enable writes |
-| $C087 | Write |  | Select LC bank 2; use RAM for reads; reset prewrite latch |
-| $C088 | Read |  | Select LC bank 1; use RAM for reads; disable writes |
-| $C088 | Write |  | Select LC bank 1; use RAM for reads; reset prewrite latch |
-| $C089 | Read |  | Select LC bank 1; use ROM for reads; arm/enable writes |
-| $C089–$C08A | Write |  | Select LC bank 1; use ROM for reads; reset prewrite latch |
-| $C08A | Read |  | Select LC bank 1; use ROM for reads; disable writes |
-| $C08B | Read |  | Select LC bank 1; use RAM for reads; arm/enable writes |
-| $C08B–$C08C | Write |  | Select LC bank 1; use RAM for reads; reset prewrite latch |
-| $C08C | Read |  | Select LC bank 1; use RAM for reads; disable writes |
-| $C08D | Read |  | Select LC bank 1; use ROM for reads; arm/enable writes |
-| $C08D–$C08E | Write |  | Select LC bank 1; use ROM for reads; reset prewrite latch |
-| $C08E | Read |  | Select LC bank 1; use ROM for reads; disable writes |
-| $C08F | Read |  | Select LC bank 1; use RAM for reads; arm/enable writes |
-| $C08F | Write |  | Select LC bank 1; use RAM for reads; reset prewrite latch |
+| $C069 | Read | $00 | Pushbutton 0 mirror: `RELEASED` (MSB = `0`) |
+| $C069 | Read | $80 | Pushbutton 0 mirror: `PRESSED` (MSB = `1`) |
+| $C06A | Read | $00 | Pushbutton 1 mirror: `RELEASED` (MSB = `0`) |
+| $C06A | Read | $80 | Pushbutton 1 mirror: `PRESSED` (MSB = `1`) |
+| $C06B | Read | $00 | Pushbutton 2 mirror: `RELEASED` (MSB = `0`) |
+| $C06B | Read | $80 | Pushbutton 2 mirror: `PRESSED` (MSB = `1`) |
+| $C06C | Read | $00 | Paddle 0 timer mirror: `EXPIRED` (MSB = `0`) |
+| $C06C | Read | $80 | Paddle 0 timer mirror: `ACTIVE` (MSB = `1`) |
+| $C06D | Read | $00 | Paddle 1 timer mirror: `EXPIRED` (MSB = `0`) |
+| $C06D | Read | $80 | Paddle 1 timer mirror: `ACTIVE` (MSB = `1`) |
+| $C06E | Read | $00 | Paddle 2 timer mirror: `EXPIRED` (MSB = `0`) |
+| $C06E | Read | $80 | Paddle 2 timer mirror: `ACTIVE` (MSB = `1`) |
+| $C06F | Read | $00 | Paddle 3 timer mirror: `EXPIRED` (MSB = `0`) |
+| $C06F | Read | $80 | Paddle 3 timer mirror: `ACTIVE` (MSB = `1`) |
+| $C070–$C073 | Read/write |  | Start paddle timers |
+| $C074 | Read |  | Start paddle timers |
+| $C074 | Write | $00 | Start paddle timers<br>TransWarp: Select configured maximum speed<br>Laser 128EX: Select 1 MHz maximum CPU speed<br>Laser 128EX: Disable automatic 1 MHz slowdown for port 7 disk access (write-once bit 5) |
+| $C074 | Write | $01 | Start paddle timers<br>TransWarp: Select 1 MHz<br>Laser 128EX: Select 1 MHz maximum CPU speed<br>Laser 128EX: Disable automatic 1 MHz slowdown for port 7 disk access (write-once bit 5) |
+| $C074 | Write | $03 | Start paddle timers<br>TransWarp: Disable acceleration until cold boot<br>Laser 128EX: Select 1 MHz maximum CPU speed<br>Laser 128EX: Disable automatic 1 MHz slowdown for port 7 disk access (write-once bit 5) |
+| $C074 | Write | $40 | Start paddle timers<br>Laser 128EX: Select 1 MHz maximum CPU speed<br>Laser 128EX: Disable automatic 1 MHz slowdown for port 7 disk access (write-once bit 5) |
+| $C074 | Write | $A0 | Start paddle timers<br>Laser 128EX: Select 2.3 MHz maximum CPU speed<br>Laser 128EX: Enable automatic 1 MHz slowdown for port 7 disk access (write-once bit 5) |
+| $C074 | Write | $C0 | Start paddle timers<br>Laser 128EX: Select 3.6 MHz maximum CPU speed<br>Laser 128EX: Disable automatic 1 MHz slowdown for port 7 disk access (write-once bit 5) |
+| $C075–$C07F | Read/write |  | Start paddle timers |
+| $C080 | Read |  | Language Card: Select bank 2<br>Language Card: Use RAM for reads<br>Language Card: Disable writes |
+| $C080 | Write |  | Language Card: Select bank 2<br>Language Card: Use RAM for reads<br>Language Card: Reset prewrite latch |
+| $C081 | Read |  | Language Card: Select bank 2<br>Language Card: Use ROM for reads<br>Language Card: Arm or enable writes |
+| $C081–$C082 | Write |  | Language Card: Select bank 2<br>Language Card: Use ROM for reads<br>Language Card: Reset prewrite latch |
+| $C082 | Read |  | Language Card: Select bank 2<br>Language Card: Use ROM for reads<br>Language Card: Disable writes |
+| $C083 | Read |  | Language Card: Select bank 2<br>Language Card: Use RAM for reads<br>Language Card: Arm or enable writes |
+| $C083–$C084 | Write |  | Language Card: Select bank 2<br>Language Card: Use RAM for reads<br>Language Card: Reset prewrite latch |
+| $C084 | Read |  | Language Card: Select bank 2<br>Language Card: Use RAM for reads<br>Language Card: Disable writes |
+| $C085 | Read |  | Language Card: Select bank 2<br>Language Card: Use ROM for reads<br>Language Card: Arm or enable writes |
+| $C085–$C086 | Write |  | Language Card: Select bank 2<br>Language Card: Use ROM for reads<br>Language Card: Reset prewrite latch |
+| $C086 | Read |  | Language Card: Select bank 2<br>Language Card: Use ROM for reads<br>Language Card: Disable writes |
+| $C087 | Read |  | Language Card: Select bank 2<br>Language Card: Use RAM for reads<br>Language Card: Arm or enable writes |
+| $C087 | Write |  | Language Card: Select bank 2<br>Language Card: Use RAM for reads<br>Language Card: Reset prewrite latch |
+| $C088 | Read |  | Language Card: Select bank 1<br>Language Card: Use RAM for reads<br>Language Card: Disable writes |
+| $C088 | Write |  | Language Card: Select bank 1<br>Language Card: Use RAM for reads<br>Language Card: Reset prewrite latch |
+| $C089 | Read |  | Language Card: Select bank 1<br>Language Card: Use ROM for reads<br>Language Card: Arm or enable writes |
+| $C089–$C08A | Write |  | Language Card: Select bank 1<br>Language Card: Use ROM for reads<br>Language Card: Reset prewrite latch |
+| $C08A | Read |  | Language Card: Select bank 1<br>Language Card: Use ROM for reads<br>Language Card: Disable writes |
+| $C08B | Read |  | Language Card: Select bank 1<br>Language Card: Use RAM for reads<br>Language Card: Arm or enable writes |
+| $C08B–$C08C | Write |  | Language Card: Select bank 1<br>Language Card: Use RAM for reads<br>Language Card: Reset prewrite latch |
+| $C08C | Read |  | Language Card: Select bank 1<br>Language Card: Use RAM for reads<br>Language Card: Disable writes |
+| $C08D | Read |  | Language Card: Select bank 1<br>Language Card: Use ROM for reads<br>Language Card: Arm or enable writes |
+| $C08D–$C08E | Write |  | Language Card: Select bank 1<br>Language Card: Use ROM for reads<br>Language Card: Reset prewrite latch |
+| $C08E | Read |  | Language Card: Select bank 1<br>Language Card: Use ROM for reads<br>Language Card: Disable writes |
+| $C08F | Read |  | Language Card: Select bank 1<br>Language Card: Use RAM for reads<br>Language Card: Arm or enable writes |
+| $C08F | Write |  | Language Card: Select bank 1<br>Language Card: Use RAM for reads<br>Language Card: Reset prewrite latch |
+
+## Instruction-sensitive cases
+
+These representative instructions exercise tooltips whose meaning or warning depends on how the instruction accesses the soft switch. Indexed and indirect examples assume that the displayed instruction is at the current PC; paused state does not reliably resolve those operands on other rows (issue #303).
+
+| Instruction | Write value | Tooltip |
+|---|---|---|
+| `INC $C030` | — | WARNING: This instruction triggers the soft switch multiple times |
+| `STA $C070,X (X = $03)` | $03 | Start paddle timers<br>WARNING: This instruction triggers the soft switch multiple times |
+| `INC $C073` | UNKNOWN | Start paddle timers |
+| `STA $C070,X (X = $04)` | $01 | Start paddle timers<br>WARNING: This instruction triggers the soft switch multiple times<br>TransWarp: Select 1 MHz<br>Laser 128EX: Select 1 MHz maximum CPU speed<br>Laser 128EX: Disable automatic 1 MHz slowdown for port 7 disk access (write-once bit 5) |
+| `INC $C074` | UNKNOWN | Start paddle timers<br>WARNING: This instruction writes an unknown value |

--- a/docs/reviews/disassembly-translation-keys.md
+++ b/docs/reviews/disassembly-translation-keys.md
@@ -1,0 +1,232 @@
+# Disassembly translation-key structure review
+
+This catalog contains 98 strings: 0 direct strings and 98 strings in 14 named groups.
+
+Keys are grouped by hardware or UI concern. Every entry is a complete rendered line; interpolation supplies runtime data rather than separately translated fragments.
+
+## Longest relative key paths
+
+| Length | Key | English |
+|---:|---|---|
+| 31 | `display.selectFullScreenDisplay` | Select full-screen display |
+| 31 | `languageCard.resetPrewriteLatch` | Language Card: Reset prewrite latch |
+| 30 | `auxMemory.altzpStatusAuxiliary` | Zero page, stack, and bank-switched RAM: AUXILIARY (MSB = 1) |
+| 30 | `display.selectAlternateCharset` | Select alternate character set |
+| 30 | `displayMemory.80storeStatusOff` | PAGE2 selects display page 1 or 2 (MSB = 0) |
+| 30 | `displayMemory.page2StatusClear` | Display-memory selection: PAGE 1 OR MAIN (MSB = 0) |
+| 30 | `languageCard.armOrEnableWrites` | Language Card: Arm or enable writes |
+| 30 | `laser128ex.disableDiskSlowdown` | Laser 128EX: Disable automatic 1 MHz slowdown for port 7 disk access (write-once bit 5) |
+| 30 | `transWarp.disableUntilColdBoot` | TransWarp: Disable acceleration until cold boot |
+| 29 | `auxMemory.selectExpansionBank` | Select auxiliary expansion bank {{bank}} using {{addressing}} addressing |
+| 29 | `display.mixedDisplayStatusOff` | Mixed display: OFF (MSB = 0) |
+| 29 | `display.verticalBlankInactive` | Vertical blank: INACTIVE (MSB = 1) |
+| 29 | `displayMemory.80storeStatusOn` | PAGE2 selects main or auxiliary display memory (MSB = 1) |
+| 29 | `laser128ex.enableDiskSlowdown` | Laser 128EX: Enable automatic 1 MHz slowdown for port 7 disk access (write-once bit 5) |
+| 28 | `display.mixedDisplayStatusOn` | Mixed display: ON (MSB = 1) |
+| 28 | `display.selectPrimaryCharset` | Select primary character set |
+| 28 | `displayMemory.page2StatusSet` | Display-memory selection: PAGE 2 OR AUXILIARY (MSB = 1) |
+| 27 | `display.altCharsetStatusOff` | Alternate character set: OFF (MSB = 0) |
+| 27 | `display.selectHiresGraphics` | Select hi-res graphics |
+| 27 | `display.selectLoresGraphics` | Select lo-res graphics |
+| 27 | `display.verticalBlankActive` | Vertical blank: ACTIVE (MSB = 0) |
+| 27 | `gameIO.buttonMirrorReleased` | Pushbutton {{number}} mirror: RELEASED (MSB = 0) |
+| 27 | `languageCard.useRamForReads` | Language Card: Use RAM for reads |
+| 27 | `languageCard.useRomForReads` | Language Card: Use ROM for reads |
+| 27 | `laser128ex.threePointSixMhz` | Laser 128EX: Select 3.6 MHz maximum CPU speed |
+| 27 | `laser128ex.twoPointThreeMhz` | Laser 128EX: Select 2.3 MHz maximum CPU speed |
+| 27 | `transWarp.configuredMaximum` | TransWarp: Select configured maximum speed |
+| 26 | `cassette.sampleInputMirror` | Sample cassette-input mirror |
+| 26 | `display.altCharsetStatusOn` | Alternate character set: ON (MSB = 1) |
+| 26 | `display.hiresModeStatusOff` | Hi-res mode: OFF (MSB = 0) |
+| 26 | `display.selectGraphicsMode` | Select graphics mode |
+| 26 | `display.selectMixedDisplay` | Select mixed graphics/text |
+| 26 | `gameIO.buttonMirrorPressed` | Pushbutton {{number}} mirror: PRESSED (MSB = 1) |
+| 26 | `gameIO.paddleMirrorExpired` | Paddle {{number}} timer mirror: EXPIRED (MSB = 0) |
+| 26 | `languageCard.disableWrites` | Language Card: Disable writes |
+| 26 | `languageCard.readSourceRam` | Language Card read source: RAM (MSB = 1) |
+| 26 | `languageCard.readSourceRom` | Language Card read source: ROM (MSB = 0) |
+| 25 | `auxMemory.altzpStatusMain` | Zero page, stack, and bank-switched RAM: MAIN (MSB = 0) |
+| 25 | `display.column80StatusOff` | 80-column display: OFF (MSB = 0) |
+| 25 | `display.hiresModeStatusOn` | Hi-res mode: ON (MSB = 1) |
+| 25 | `display.textModeStatusOff` | Text mode: OFF (MSB = 0) |
+| 25 | `displayMemory.selectPage1` | Select display page 1 |
+| 25 | `displayMemory.selectPage2` | Select display page 2 |
+| 25 | `gameIO.paddleMirrorActive` | Paddle {{number}} timer mirror: ACTIVE (MSB = 1) |
+| 25 | `notice.emulatorIdentifier` | INFO: Apple2TS emulator identifier: $CD |
+| 24 | `auxMemory.altzpAuxiliary` | Select auxiliary zero page, stack, and bank-switched RAM |
+| 24 | `auxMemory.writeAuxiliary` | Select auxiliary memory for writes |
+| 24 | `auxMemory.writeStatusOff` | Auxiliary-memory writes: OFF (MSB = 0) |
+| 24 | `display.column80StatusOn` | 80-column display: ON (MSB = 1) |
+| 24 | `display.textModeStatusOn` | Text mode: ON (MSB = 1) |
+| 24 | `displayMemory.80storeOff` | Make PAGE2 select display page 1 or 2 |
+| 24 | `displayMemory.page2Clear` | Select display page 1, or main display memory with 80STORE |
+| 24 | `gameIO.startPaddleTimers` | Start paddle timers |
+| 24 | `keyboard.anyKeyDownClear` | Any-key-down flag: CLEAR (MSB = 0) |
+
+## memory
+
+| Key | English | Fields |
+|---|---|---|
+| `memory.effectiveAddress` | Effective address: {{notation}} | notation |
+| `memory.value` | Value: {{notation}} | notation |
+
+## keyboard
+
+| Key | English | Fields |
+|---|---|---|
+| `keyboard.character` | Keyboard: "{{character}}" | character |
+| `keyboard.strobeClear` | Keyboard strobe: CLEAR (MSB = 0) | — |
+| `keyboard.strobeSet` | Keyboard strobe: SET (MSB = 1) | — |
+| `keyboard.anyKeyDownClear` | Any-key-down flag: CLEAR (MSB = 0) | — |
+| `keyboard.anyKeyDownSet` | Any-key-down flag: SET (MSB = 1) | — |
+| `keyboard.clearStrobe` | Clear keyboard strobe | — |
+
+## cassette
+
+| Key | English | Fields |
+|---|---|---|
+| `cassette.toggleOutput` | Toggle cassette output | — |
+| `cassette.sampleInput` | Sample cassette input | — |
+| `cassette.sampleInputMirror` | Sample cassette-input mirror | — |
+
+## speaker
+
+| Key | English | Fields |
+|---|---|---|
+| `speaker.toggleOutput` | Toggle speaker output | — |
+
+## notice
+
+| Key | English | Fields |
+|---|---|---|
+| `notice.emulatorIdentifier` | INFO: Apple2TS emulator identifier: $CD | — |
+| `notice.noWriteEffect` | INFO: This write has no effect on {{machine}} | machine |
+| `notice.multipleTriggers` | WARNING: This instruction triggers the soft switch multiple times | — |
+| `notice.unknownWrite` | WARNING: This instruction writes an unknown value | — |
+
+## rom
+
+| Key | English | Fields |
+|---|---|---|
+| `rom.intCxOff` | Internal $Cx ROM: OFF (MSB = 0) | — |
+| `rom.intCxOn` | Internal $Cx ROM: ON (MSB = 1) | — |
+| `rom.slot3Off` | Slot 3 ROM: OFF (MSB = 0) | — |
+| `rom.slot3On` | Slot 3 ROM: ON (MSB = 1) | — |
+| `rom.internal` | Select internal ROM for {{range}} | range |
+| `rom.slot` | Select slot ROM for {{range}} | range |
+
+## languageCard
+
+| Key | English | Fields |
+|---|---|---|
+| `languageCard.bank1` | Language Card bank: 1 (MSB = 0) | — |
+| `languageCard.bank2` | Language Card bank: 2 (MSB = 1) | — |
+| `languageCard.readSourceRom` | Language Card read source: ROM (MSB = 0) | — |
+| `languageCard.readSourceRam` | Language Card read source: RAM (MSB = 1) | — |
+| `languageCard.selectBank` | Language Card: Select bank {{bank}} | bank |
+| `languageCard.useRamForReads` | Language Card: Use RAM for reads | — |
+| `languageCard.useRomForReads` | Language Card: Use ROM for reads | — |
+| `languageCard.disableWrites` | Language Card: Disable writes | — |
+| `languageCard.resetPrewriteLatch` | Language Card: Reset prewrite latch | — |
+| `languageCard.armOrEnableWrites` | Language Card: Arm or enable writes | — |
+
+## auxMemory
+
+| Key | English | Fields |
+|---|---|---|
+| `auxMemory.readStatusOff` | Auxiliary-memory reads: OFF (MSB = 0) | — |
+| `auxMemory.readStatusOn` | Auxiliary-memory reads: ON (MSB = 1) | — |
+| `auxMemory.readMain` | Select main memory for reads | — |
+| `auxMemory.readAuxiliary` | Select auxiliary memory for reads | — |
+| `auxMemory.writeStatusOff` | Auxiliary-memory writes: OFF (MSB = 0) | — |
+| `auxMemory.writeStatusOn` | Auxiliary-memory writes: ON (MSB = 1) | — |
+| `auxMemory.writeMain` | Select main memory for writes | — |
+| `auxMemory.writeAuxiliary` | Select auxiliary memory for writes | — |
+| `auxMemory.selectExpansionBank` | Select auxiliary expansion bank {{bank}} using {{addressing}} addressing | bank, addressing |
+| `auxMemory.altzpMain` | Select main zero page, stack, and bank-switched RAM | — |
+| `auxMemory.altzpAuxiliary` | Select auxiliary zero page, stack, and bank-switched RAM | — |
+| `auxMemory.altzpStatusMain` | Zero page, stack, and bank-switched RAM: MAIN (MSB = 0) | — |
+| `auxMemory.altzpStatusAuxiliary` | Zero page, stack, and bank-switched RAM: AUXILIARY (MSB = 1) | — |
+
+## displayMemory
+
+| Key | English | Fields |
+|---|---|---|
+| `displayMemory.80storeStatusOff` | PAGE2 selects display page 1 or 2 (MSB = 0) | — |
+| `displayMemory.80storeStatusOn` | PAGE2 selects main or auxiliary display memory (MSB = 1) | — |
+| `displayMemory.80storeOff` | Make PAGE2 select display page 1 or 2 | — |
+| `displayMemory.80storeOn` | Make PAGE2 select main or auxiliary display memory | — |
+| `displayMemory.page2StatusClear` | Display-memory selection: PAGE 1 OR MAIN (MSB = 0) | — |
+| `displayMemory.page2StatusSet` | Display-memory selection: PAGE 2 OR AUXILIARY (MSB = 1) | — |
+| `displayMemory.selectPage1` | Select display page 1 | — |
+| `displayMemory.selectPage2` | Select display page 2 | — |
+| `displayMemory.page2Clear` | Select display page 1, or main display memory with 80STORE | — |
+| `displayMemory.page2Set` | Select display page 2, or auxiliary display memory with 80STORE | — |
+
+## display
+
+| Key | English | Fields |
+|---|---|---|
+| `display.altCharsetStatusOff` | Alternate character set: OFF (MSB = 0) | — |
+| `display.altCharsetStatusOn` | Alternate character set: ON (MSB = 1) | — |
+| `display.selectPrimaryCharset` | Select primary character set | — |
+| `display.selectAlternateCharset` | Select alternate character set | — |
+| `display.textModeStatusOff` | Text mode: OFF (MSB = 0) | — |
+| `display.textModeStatusOn` | Text mode: ON (MSB = 1) | — |
+| `display.selectGraphicsMode` | Select graphics mode | — |
+| `display.selectTextMode` | Select text mode | — |
+| `display.mixedDisplayStatusOff` | Mixed display: OFF (MSB = 0) | — |
+| `display.mixedDisplayStatusOn` | Mixed display: ON (MSB = 1) | — |
+| `display.selectFullScreenDisplay` | Select full-screen display | — |
+| `display.selectMixedDisplay` | Select mixed graphics/text | — |
+| `display.hiresModeStatusOff` | Hi-res mode: OFF (MSB = 0) | — |
+| `display.hiresModeStatusOn` | Hi-res mode: ON (MSB = 1) | — |
+| `display.selectLoresGraphics` | Select lo-res graphics | — |
+| `display.selectHiresGraphics` | Select hi-res graphics | — |
+| `display.disableDhires` | Disable DHIRES | — |
+| `display.enableDhires` | Enable DHIRES | — |
+| `display.verticalBlankActive` | Vertical blank: ACTIVE (MSB = 0) | — |
+| `display.verticalBlankInactive` | Vertical blank: INACTIVE (MSB = 1) | — |
+| `display.column80StatusOff` | 80-column display: OFF (MSB = 0) | — |
+| `display.column80StatusOn` | 80-column display: ON (MSB = 1) | — |
+| `display.setWidth` | Set display width to {{columns}} columns | columns |
+
+## annunciator
+
+| Key | English | Fields |
+|---|---|---|
+| `annunciator.disable` | Disable annunciator {{number}} | number |
+| `annunciator.enable` | Enable annunciator {{number}} | number |
+
+## transWarp
+
+| Key | English | Fields |
+|---|---|---|
+| `transWarp.configuredMaximum` | TransWarp: Select configured maximum speed | — |
+| `transWarp.oneMhz` | TransWarp: Select 1 MHz | — |
+| `transWarp.disableUntilColdBoot` | TransWarp: Disable acceleration until cold boot | — |
+
+## laser128ex
+
+| Key | English | Fields |
+|---|---|---|
+| `laser128ex.oneMhz` | Laser 128EX: Select 1 MHz maximum CPU speed | — |
+| `laser128ex.twoPointThreeMhz` | Laser 128EX: Select 2.3 MHz maximum CPU speed | — |
+| `laser128ex.threePointSixMhz` | Laser 128EX: Select 3.6 MHz maximum CPU speed | — |
+| `laser128ex.disableDiskSlowdown` | Laser 128EX: Disable automatic 1 MHz slowdown for port 7 disk access (write-once bit 5) | — |
+| `laser128ex.enableDiskSlowdown` | Laser 128EX: Enable automatic 1 MHz slowdown for port 7 disk access (write-once bit 5) | — |
+
+## gameIO
+
+| Key | English | Fields |
+|---|---|---|
+| `gameIO.pulseStrobe` | Pulse game-port strobe | — |
+| `gameIO.startPaddleTimers` | Start paddle timers | — |
+| `gameIO.buttonReleased` | Pushbutton {{number}}: RELEASED (MSB = 0) | number |
+| `gameIO.buttonPressed` | Pushbutton {{number}}: PRESSED (MSB = 1) | number |
+| `gameIO.paddleExpired` | Paddle {{number}} timer: EXPIRED (MSB = 0) | number |
+| `gameIO.paddleActive` | Paddle {{number}} timer: ACTIVE (MSB = 1) | number |
+| `gameIO.buttonMirrorReleased` | Pushbutton {{number}} mirror: RELEASED (MSB = 0) | number |
+| `gameIO.buttonMirrorPressed` | Pushbutton {{number}} mirror: PRESSED (MSB = 1) | number |
+| `gameIO.paddleMirrorExpired` | Paddle {{number}} timer mirror: EXPIRED (MSB = 0) | number |
+| `gameIO.paddleMirrorActive` | Paddle {{number}} timer mirror: ACTIVE (MSB = 1) | number |

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "preview": "vite preview",
     "test": "jest",
     "review-disassembly-tooltips": "node tools/render-disassembly-tooltip-review.mjs",
+    "review-disassembly-translation-keys": "node tools/render-disassembly-tooltip-review.mjs --keys",
     "write-disassembly-tooltip-reviews": "node tools/render-disassembly-tooltip-review.mjs --write",
     "test-disassembly-tooltip-review": "node --test tools/render-disassembly-tooltip-review.test.mjs"
   },

--- a/src/i18n/README_en.md
+++ b/src/i18n/README_en.md
@@ -2,6 +2,9 @@
 
 This directory contains the core internationalization (i18n) engine and maintenance tools for Apple2TS. Refer to this guide when merging upstream changes or adding new translation keys.
 
+For primary English tooltip wording, follow the canonical forms in
+[Tooltip Style Guide](TOOLTIP_STYLE.md).
+
 ## 🛠️ Maintenance Tools
 
 ### 1. `i18n_master.cjs` — Deprecated

--- a/src/i18n/TOOLTIP_STYLE.md
+++ b/src/i18n/TOOLTIP_STYLE.md
@@ -1,0 +1,266 @@
+# Tooltip Style Guide
+
+English catalog messages are the source text for every Apple2TS translation.
+Keep tooltips concise, consistent, and complete enough for natural translation.
+The first sections guide tooltip writers. **Implementation Notes** covers
+catalog and rendering code.
+
+## Terminology
+
+- **Message:** one catalog entry translated and rendered as a unit. It may
+  contain fixed text, interpolation variables, or both.
+- **Interpolation variable:** raw data inserted through a named field such as
+  `{{value}}`. Keep translated words and sentence fragments in the message.
+  Data may include a resolved do-not-translate identifier such as a published
+  product name.
+- **Do-not-translate content:** published product names, hardware identifiers,
+  addresses, and technical notation that must remain unchanged.
+- **Localization note:** translator guidance about context, variables,
+  do-not-translate content, or the supporting hardware documentation.
+
+## Core Rules
+
+### Writing Messages
+
+- Each message renders one complete line for one UI concept or hardware effect.
+- A noun phrase can be a complete tooltip.
+- Write each complete line as one translation message, even when that repeats
+  a term. Avoid assembling a line from separately translated words or
+  fragments.
+- Avoid splitting messages at a colon; a colon does not always make its parts
+  grammatically independent.
+- Use sentence case.
+- Preserve conventional capitalization for product names, acronyms, register
+  names, and values.
+- Base user-facing text on official hardware terminology.
+- Explain the effect without repeating the disassembly symbol already under
+  the pointer.
+
+### Runtime Data
+
+- Use named interpolation variables only for clear runtime data.
+- Keep fixed do-not-translate content in the source message.
+
+### Localization Notes
+
+- Add a note when a variable, identifier, or hardware context is unclear.
+- Identify do-not-translate content in the note.
+- Link hardware documentation when the note relies on device-specific facts.
+
+## UI Tooltips
+
+### Labels
+
+- Use a concise noun phrase when a tooltip identifies a control or concern:
+
+  ```text
+  Emulator Speed
+  Debug Panel
+  Machine Configuration
+  ```
+
+- Keep the complete phrase in one message.
+- Add an imperative verb only when the tooltip describes an action.
+
+### Actions
+
+- Use a concise imperative when the control's purpose is the action itself:
+
+  ```text
+  Boot
+  Reset
+  Copy Screen
+  Step Over
+  ```
+
+- Keep the verb and its object in one message.
+- Use a standalone verb only when the surrounding UI makes its object clear.
+
+### Information
+
+- Use a direct explanatory message when a tooltip describes capability or
+  context:
+
+  ```text
+  These buttons save and restore the complete emulator state.
+  ```
+
+- Prefer a natural sentence, but use shorter wording when it conveys the whole
+  meaning.
+
+## Disassembly Tooltips
+
+### Memory Details
+
+- Translate each labeled memory detail while inserting technical notation as
+  runtime data:
+
+  ```text
+  Effective address: $2003 = $2000 + $03
+  Effective address: $1234 = ($23), $23 = $20 + $03
+  Value: $42
+  ```
+
+- Keep hexadecimal values, operators, ordering, and grouping identical in
+  every language.
+
+### Raw Technical Notation
+
+- Keep a tooltip untranslated when it contains only machine notation:
+
+  ```text
+  $1234
+  93 = 01011101 = "]"
+  ```
+
+- Use this form for raw jump targets and immediate-value breakdowns. Add a
+  translated message when explanatory text is needed.
+
+### Observed Status
+
+- Use an observed-status message when Apple2TS interprets an available runtime
+  value:
+
+  ```text
+  Keyboard strobe: SET (MSB = 1)
+  Any-key-down flag: CLEAR (MSB = 0)
+  Text mode: ON (MSB = 1)
+  Language Card read source: RAM (MSB = 1)
+  Zero page, stack, and bank-switched RAM: AUXILIARY (MSB = 1)
+  ```
+
+- Translate the whole status message so each language controls word order and
+  punctuation.
+
+### Hardware Actions
+
+- Use a complete imperative message when an access causes an action:
+
+  ```text
+  Clear keyboard strobe
+  Toggle speaker output
+  Enable DHIRES
+  Disable annunciator 3
+  Select display page 2, or auxiliary display memory with 80STORE
+  Set display width to 80 columns
+  ```
+
+- Keep the verb, object, and translated qualifiers together.
+- Interpolate only runtime data, such as a bank number or display width.
+- Use imperative wording for actions and declarative wording for observed
+  states.
+- Keep paired enable/disable actions and enumerated selections as complete,
+  independently translated messages.
+
+### Device-Scoped Actions
+
+- Include the device name in the complete message when hardware identity
+  distinguishes an action:
+
+  ```text
+  Language Card: Select bank 2
+  TransWarp: Select 1 MHz
+  Laser 128EX: Select 2.3 MHz maximum CPU speed
+  FASTChip IIe: Advance unlock sequence
+  ```
+
+- Translate generic device names such as `Language Card` within each message.
+- Retain published product names such as `TransWarp` and `Laser 128EX`.
+- Use `Language Card` as the concise UI label. Apple calls the IIe
+  implementation the "Built-in Language Card."
+
+### Warnings
+
+- Use a warning when an instruction can produce a meaningful but unpredictable
+  effect:
+
+  ```text
+  WARNING: This instruction triggers the soft switch multiple times
+  WARNING: This instruction writes an unknown value
+  ```
+
+- Keep each consequence as a complete message.
+- Include the translated severity in each complete warning message.
+- Reserve warnings for established, actionable consequences.
+
+### Contextual Diagnostics
+
+- Use `INFO:` for helpful context without a hazardous or unpredictable effect:
+
+  ```text
+  INFO: This write has no effect on Apple II+
+  ```
+
+- Keep contextual diagnostics separate from generic status and action
+  messages.
+
+### Multiple Effects
+
+- Display independent effects on separate lines:
+
+  ```text
+  Language Card: Select bank 2
+  Language Card: Use RAM for reads
+  Language Card: Reset prewrite latch
+  ```
+
+- Keep each line as one complete translation message, even when one access
+  causes every listed effect.
+
+## Implementation Notes
+
+These rules apply to code that selects and renders tooltip messages.
+
+### Catalog Keys
+
+- Group messages by hardware or UI concern rather than disassembly symbol.
+- Keep a stable hardware identifier in a leaf key when it aids discovery.
+- Derive keys from stable concepts rather than current English wording.
+
+### Message Selection
+
+- Choose the semantic message key before applying a language.
+- Translation changes presentation only; the selected key determines hardware
+  meaning.
+- When a runtime byte is unavailable, retain the generic address detail and
+  omit semantic status. Treat `UNKNOWN` as missing evidence, not a third
+  hardware state.
+
+### Device Context
+
+- Lead with the selected machine's motherboard effect when an access also has
+  optional-device meaning.
+- Show optional-device intent only when machine, access, known-value, or
+  sequence evidence supports it.
+- Treat ordinary motherboard reads as motherboard actions.
+- Distinguish an optional card from similar behavior built into a later
+  motherboard.
+- Once card configuration exists, show II+ Language Card actions only if the
+  card is present.
+
+### Rendering
+
+- Resolve independent effects separately and render each message on its own
+  line. Keep a computed effective-address message on its own line before the
+  semantic effects; omit it for a direct operand whose address is already
+  visible in the disassembly.
+- Treat an indexed or indirect effective address as authoritative only for the
+  instruction at the current PC. The paused CPU's registers and pointer memory
+  do not establish what an earlier row used or a later row will use. Keep this
+  limitation explicit in review material while issue #303 owns the follow-up.
+- Place any stable hardware effects before warnings.
+- Pass a resolved hardware identifier as raw data only when it varies at
+  runtime.
+- Preserve computed address and value notation from left to right in every
+  language. Pass it through `{{notation}}` and isolate it from surrounding
+  translated text in the renderer. For example, keep `$2003 = $2000 + $03`
+  in that order.
+- Keep supplemental `INFO:` and `WARNING:` messages in the disassembly
+  `notice` group. Preserve the visible severity in each complete message.
+
+## References
+
+- [GNU gettext: Entire Sentences](https://www.gnu.org/software/gettext/manual/html_node/Entire-sentences.html)
+- [ICU: Formatting Messages](https://unicode-org.github.io/icu/userguide/format_parse/messages/)
+- [i18next: Interpolation](https://www.i18next.com/translation-function/interpolation)
+- [W3C: Working with Composite Messages](https://www.w3.org/International/articles/composite-messages/)

--- a/src/i18n/languages/en.ts
+++ b/src/i18n/languages/en.ts
@@ -72,7 +72,6 @@ export const en = {
     basicTab: "Applesoft BASIC",
     expectinTab: "Apple exPectin",
     breakpoints: "Breakpoints",
-    disassembly: "Disassembly",
     memory: "Memory",
     stack: "Stack",
     state: "CPU State",
@@ -86,143 +85,158 @@ export const en = {
     pause: "Pause",
     loadSymbolTable: "Load Symbol Table",
     agentTab: "Agent",
-    disassemblyTooltips: {
-      // Formats own grammar, word order, and punctuation. Labels and states
-      // below are standalone diagnostic terms inserted through named fields.
-      formats: {
-        unknown: "{{label}} = UNKNOWN",
-        bit7: "{{label}} = {{state}} (bit 7 = {{bit}})",
-        withAction: "{{status}}; {{action}}",
-        keyboardUnknown: "Keyboard = UNKNOWN",
-        keyboard: "Keyboard = \"{{character}}\"; Strobe is {{state}} (bit 7 = {{bit}})",
-        auxiliaryBankUnknown: "Select auxiliary bank using {{addressing}} addressing; start paddle timers",
-        auxiliaryBank: "Select auxiliary bank {{bank}} using {{addressing}} addressing; start paddle timers",
-        preIndexedAddress:
-          "Address: {{effectiveAddress}} ⇐ ({{base}} + {{index}} = {{pointer}})",
-        indexedAddress: "Address: {{effectiveAddress}} = {{base}} + {{index}}",
-        indirectAddress: "Address: {{effectiveAddress}}",
-        value: "Value: {{value}}",
-      },
-      states: {
-        "1": "1",
-        "2": "2",
-        no: "NO",
-        yes: "YES",
-        rom: "ROM",
-        ram: "RAM",
-        off: "OFF",
-        on: "ON",
-        active: "ACTIVE",
-        inactive: "INACTIVE",
-        released: "RELEASED",
-        pressed: "PRESSED",
-        expired: "EXPIRED",
-        clear: "CLEAR",
-        set: "SET",
-      },
-      labels: {
-        anyKeyDown: "Any Key Down",
-        languageCardBank: "Language Card Bank",
-        languageCardReadSource: "Language Card Read Source",
-        auxiliaryMemoryReads: "Auxiliary-Memory Reads",
-        auxiliaryMemoryWrites: "Auxiliary-Memory Writes",
-        internalCxRom: "Internal $Cx ROM",
-        auxiliaryZeroPageAndStack: "Auxiliary Zero Page and Stack",
-        slot3Rom: "Slot 3 ROM",
-        page2DisplayMemoryBanking: "PAGE2 Display-Memory Banking",
-        verticalBlank: "Vertical Blank",
-        textMode: "Text Mode",
-        mixedDisplay: "Mixed Display",
-        displayPage: "Display Page",
-        hiResMode: "Hi-Res Mode",
-        alternateCharacterSet: "Alternate Character Set",
-        "80ColumnDisplay": "80-Column Display",
-        pushbutton0: "Pushbutton 0",
-        pushbutton1: "Pushbutton 1",
-        pushbutton2: "Pushbutton 2",
-        paddle0Timer: "Paddle 0 Timer",
-        paddle1Timer: "Paddle 1 Timer",
-        paddle2Timer: "Paddle 2 Timer",
-        paddle3Timer: "Paddle 3 Timer",
-        pushbutton0Mirror: "Pushbutton 0 Mirror",
-        pushbutton1Mirror: "Pushbutton 1 Mirror",
-        pushbutton2Mirror: "Pushbutton 2 Mirror",
-        paddle0TimerMirror: "Paddle 0 Timer Mirror",
-        paddle1TimerMirror: "Paddle 1 Timer Mirror",
-        paddle2TimerMirror: "Paddle 2 Timer Mirror",
-        paddle3TimerMirror: "Paddle 3 Timer Mirror",
-      },
-      text: {
-        clearKeyboardStrobe: "Clear keyboard strobe",
-        writeIgnoredOnAppleIiPlus: "Write ignored on Apple II+",
-        disablePage2DisplayMemoryBanking: "Disable PAGE2 display-memory banking",
-        enablePage2DisplayMemoryBanking: "Enable PAGE2 display-memory banking",
-        selectMainMemoryForReads: "Select main memory for reads",
-        selectAuxiliaryMemoryForReads: "Select auxiliary memory for reads",
-        selectMainMemoryForWrites: "Select main memory for writes",
-        selectAuxiliaryMemoryForWrites: "Select auxiliary memory for writes",
-        selectSlotRomForC100Cfff: "Select slot ROM for $C100-$CFFF",
-        selectInternalRomForC100Cfff: "Select internal ROM for $C100-$CFFF",
-        selectMainZeroPageAndStack: "Select main zero page and stack",
-        selectAuxiliaryZeroPageAndStack: "Select auxiliary zero page and stack",
-        selectInternalRomForC300C3ff: "Select internal ROM for $C300-$C3FF",
-        selectSlot3Rom: "Select slot 3 ROM",
-        select40ColumnDisplay: "Select 40-column display",
-        select80ColumnDisplay: "Select 80-column display",
-        selectPrimaryCharacterSet: "Select primary character set",
-        selectAlternateCharacterSet: "Select alternate character set",
-        toggleCassetteOutput: "Toggle cassette output",
-        toggleSpeakerOutput: "Toggle speaker output",
-        pulseGamePortStrobe: "Pulse game-port strobe",
-        apple2tsEmulationMarkerAlwaysCd: "Apple2TS emulation marker always = $CD",
-        selectGraphicsMode: "Select graphics mode",
-        selectTextMode: "Select text mode",
-        selectFullScreenDisplay: "Select full-screen display",
-        selectMixedGraphicsText: "Select mixed graphics/text",
-        selectDisplayPage1: "Select display page 1",
-        selectDisplayPage2: "Select display page 2",
-        selectLoResGraphics: "Select lo-res graphics",
-        selectHiResGraphics: "Select hi-res graphics",
-        disableAnnunciator0: "Disable annunciator 0",
-        enableAnnunciator0: "Enable annunciator 0",
-        disableAnnunciator1: "Disable annunciator 1",
-        enableAnnunciator1: "Enable annunciator 1",
-        disableAnnunciator2: "Disable annunciator 2",
-        enableAnnunciator2: "Enable annunciator 2",
-        disableAnnunciator3EnableDhires: "Disable annunciator 3; enable DHIRES",
-        enableAnnunciator3DisableDhires: "Enable annunciator 3; disable DHIRES",
-        disableAnnunciator3: "Disable annunciator 3",
-        enableAnnunciator3: "Enable annunciator 3",
-        sampleCassetteInput: "Sample cassette input",
-        sampleCassetteInputMirror: "Sample cassette-input mirror",
-        startPaddleTimers: "Start paddle timers",
-        laser128exCompatibilityNotEmulated: "Laser 128EX compatibility = NOT EMULATED",
-        selectLcBank2UseRamForReadsDisableWrites:
-          "Select LC bank 2; use RAM for reads; disable writes",
-        selectLcBank2UseRamForReadsResetPrewriteLatch:
-          "Select LC bank 2; use RAM for reads; reset prewrite latch",
-        selectLcBank2UseRomForReadsArmEnableWrites:
-          "Select LC bank 2; use ROM for reads; arm/enable writes",
-        selectLcBank2UseRomForReadsResetPrewriteLatch:
-          "Select LC bank 2; use ROM for reads; reset prewrite latch",
-        selectLcBank2UseRomForReadsDisableWrites:
-          "Select LC bank 2; use ROM for reads; disable writes",
-        selectLcBank2UseRamForReadsArmEnableWrites:
-          "Select LC bank 2; use RAM for reads; arm/enable writes",
-        selectLcBank1UseRamForReadsDisableWrites:
-          "Select LC bank 1; use RAM for reads; disable writes",
-        selectLcBank1UseRamForReadsResetPrewriteLatch:
-          "Select LC bank 1; use RAM for reads; reset prewrite latch",
-        selectLcBank1UseRomForReadsArmEnableWrites:
-          "Select LC bank 1; use ROM for reads; arm/enable writes",
-        selectLcBank1UseRomForReadsResetPrewriteLatch:
-          "Select LC bank 1; use ROM for reads; reset prewrite latch",
-        selectLcBank1UseRomForReadsDisableWrites:
-          "Select LC bank 1; use ROM for reads; disable writes",
-        selectLcBank1UseRamForReadsArmEnableWrites:
-          "Select LC bank 1; use RAM for reads; arm/enable writes",
-        triggerMultipleSoftSwitchOperations: "Trigger multiple soft-switch operations",
-      },
+    disassembly: "Disassembly",
+  },
+  disassembly: {
+    // Each message is one complete tooltip implication. The disassembler can
+    // present several implications from one memory access as separate lines.
+    // Name messages for their hardware concern and reuse them only when the
+    // complete implication has the same meaning in both contexts.
+    // Every message is one complete rendered line. Interpolation supplies
+    // runtime data, never separately translated words or sentence fragments.
+    // Computed effective address and current memory value.
+    memory: {
+      effectiveAddress: "Effective address: {{notation}}",
+      value: "Value: {{notation}}",
+    },
+    // Keyboard input and strobe behavior.
+    keyboard: {
+      character: "Keyboard: \"{{character}}\"",
+      strobeClear: "Keyboard strobe: CLEAR (MSB = 0)",
+      strobeSet: "Keyboard strobe: SET (MSB = 1)",
+      anyKeyDownClear: "Any-key-down flag: CLEAR (MSB = 0)",
+      anyKeyDownSet: "Any-key-down flag: SET (MSB = 1)",
+      clearStrobe: "Clear keyboard strobe",
+    },
+    // Cassette input and output.
+    cassette: {
+      toggleOutput: "Toggle cassette output",
+      sampleInput: "Sample cassette input",
+      sampleInputMirror: "Sample cassette-input mirror",
+    },
+    // Speaker output.
+    speaker: {
+      toggleOutput: "Toggle speaker output",
+    },
+    // Supplemental INFO and WARNING messages.
+    notice: {
+      emulatorIdentifier: "INFO: Apple2TS emulator identifier: $CD",
+      noWriteEffect: "INFO: This write has no effect on {{machine}}",
+      multipleTriggers: "WARNING: This instruction triggers the soft switch multiple times",
+      unknownWrite: "WARNING: This instruction writes an unknown value",
+    },
+    // ROM source and mapping.
+    rom: {
+      intCxOff: "Internal $Cx ROM: OFF (MSB = 0)",
+      intCxOn: "Internal $Cx ROM: ON (MSB = 1)",
+      slot3Off: "Slot 3 ROM: OFF (MSB = 0)",
+      slot3On: "Slot 3 ROM: ON (MSB = 1)",
+      internal: "Select internal ROM for {{range}}",
+      slot: "Select slot ROM for {{range}}",
+    },
+    // Language Card banking and access.
+    languageCard: {
+      bank1: "Language Card bank: 1 (MSB = 0)",
+      bank2: "Language Card bank: 2 (MSB = 1)",
+      readSourceRom: "Language Card read source: ROM (MSB = 0)",
+      readSourceRam: "Language Card read source: RAM (MSB = 1)",
+      selectBank: "Language Card: Select bank {{bank}}",
+      useRamForReads: "Language Card: Use RAM for reads",
+      useRomForReads: "Language Card: Use ROM for reads",
+      disableWrites: "Language Card: Disable writes",
+      resetPrewriteLatch: "Language Card: Reset prewrite latch",
+      armOrEnableWrites: "Language Card: Arm or enable writes",
+    },
+    // Auxiliary-memory routing and expansion banks.
+    auxMemory: {
+      readStatusOff: "Auxiliary-memory reads: OFF (MSB = 0)",
+      readStatusOn: "Auxiliary-memory reads: ON (MSB = 1)",
+      readMain: "Select main memory for reads",
+      readAuxiliary: "Select auxiliary memory for reads",
+      writeStatusOff: "Auxiliary-memory writes: OFF (MSB = 0)",
+      writeStatusOn: "Auxiliary-memory writes: ON (MSB = 1)",
+      writeMain: "Select main memory for writes",
+      writeAuxiliary: "Select auxiliary memory for writes",
+      selectExpansionBank:
+        "Select auxiliary expansion bank {{bank}} using {{addressing}} addressing",
+      altzpMain: "Select main zero page, stack, and bank-switched RAM",
+      altzpAuxiliary: "Select auxiliary zero page, stack, and bank-switched RAM",
+      altzpStatusMain: "Zero page, stack, and bank-switched RAM: MAIN (MSB = 0)",
+      altzpStatusAuxiliary:
+        "Zero page, stack, and bank-switched RAM: AUXILIARY (MSB = 1)",
+    },
+    // Which memory supplies the display.
+    displayMemory: {
+      "80storeStatusOff": "PAGE2 selects display page 1 or 2 (MSB = 0)",
+      "80storeStatusOn": "PAGE2 selects main or auxiliary display memory (MSB = 1)",
+      "80storeOff": "Make PAGE2 select display page 1 or 2",
+      "80storeOn": "Make PAGE2 select main or auxiliary display memory",
+      page2StatusClear: "Display-memory selection: PAGE 1 OR MAIN (MSB = 0)",
+      page2StatusSet: "Display-memory selection: PAGE 2 OR AUXILIARY (MSB = 1)",
+      selectPage1: "Select display page 1",
+      selectPage2: "Select display page 2",
+      page2Clear: "Select display page 1, or main display memory with 80STORE",
+      page2Set: "Select display page 2, or auxiliary display memory with 80STORE",
+    },
+    // How and when video is rendered.
+    display: {
+      altCharsetStatusOff: "Alternate character set: OFF (MSB = 0)",
+      altCharsetStatusOn: "Alternate character set: ON (MSB = 1)",
+      selectPrimaryCharset: "Select primary character set",
+      selectAlternateCharset: "Select alternate character set",
+      textModeStatusOff: "Text mode: OFF (MSB = 0)",
+      textModeStatusOn: "Text mode: ON (MSB = 1)",
+      selectGraphicsMode: "Select graphics mode",
+      selectTextMode: "Select text mode",
+      mixedDisplayStatusOff: "Mixed display: OFF (MSB = 0)",
+      mixedDisplayStatusOn: "Mixed display: ON (MSB = 1)",
+      selectFullScreenDisplay: "Select full-screen display",
+      selectMixedDisplay: "Select mixed graphics/text",
+      hiresModeStatusOff: "Hi-res mode: OFF (MSB = 0)",
+      hiresModeStatusOn: "Hi-res mode: ON (MSB = 1)",
+      selectLoresGraphics: "Select lo-res graphics",
+      selectHiresGraphics: "Select hi-res graphics",
+      disableDhires: "Disable DHIRES",
+      enableDhires: "Enable DHIRES",
+      verticalBlankActive: "Vertical blank: ACTIVE (MSB = 0)",
+      verticalBlankInactive: "Vertical blank: INACTIVE (MSB = 1)",
+      column80StatusOff: "80-column display: OFF (MSB = 0)",
+      column80StatusOn: "80-column display: ON (MSB = 1)",
+      setWidth: "Set display width to {{columns}} columns",
+    },
+    // Annunciator output.
+    annunciator: {
+      disable: "Disable annunciator {{number}}",
+      enable: "Enable annunciator {{number}}",
+    },
+    // TransWarp-specific software intent.
+    transWarp: {
+      configuredMaximum: "TransWarp: Select configured maximum speed",
+      oneMhz: "TransWarp: Select 1 MHz",
+      disableUntilColdBoot: "TransWarp: Disable acceleration until cold boot",
+    },
+    // Laser 128EX-specific software intent.
+    laser128ex: {
+      oneMhz: "Laser 128EX: Select 1 MHz maximum CPU speed",
+      twoPointThreeMhz: "Laser 128EX: Select 2.3 MHz maximum CPU speed",
+      threePointSixMhz: "Laser 128EX: Select 3.6 MHz maximum CPU speed",
+      disableDiskSlowdown:
+        "Laser 128EX: Disable automatic 1 MHz slowdown for port 7 disk access (write-once bit 5)",
+      enableDiskSlowdown:
+        "Laser 128EX: Enable automatic 1 MHz slowdown for port 7 disk access (write-once bit 5)",
+    },
+    // Game-port input and output.
+    gameIO: {
+      pulseStrobe: "Pulse game-port strobe",
+      startPaddleTimers: "Start paddle timers",
+      buttonReleased: "Pushbutton {{number}}: RELEASED (MSB = 0)",
+      buttonPressed: "Pushbutton {{number}}: PRESSED (MSB = 1)",
+      paddleExpired: "Paddle {{number}} timer: EXPIRED (MSB = 0)",
+      paddleActive: "Paddle {{number}} timer: ACTIVE (MSB = 1)",
+      buttonMirrorReleased: "Pushbutton {{number}} mirror: RELEASED (MSB = 0)",
+      buttonMirrorPressed: "Pushbutton {{number}} mirror: PRESSED (MSB = 1)",
+      paddleMirrorExpired: "Paddle {{number}} timer mirror: EXPIRED (MSB = 0)",
+      paddleMirrorActive: "Paddle {{number}} timer mirror: ACTIVE (MSB = 1)",
     },
   },
   tour: {

--- a/src/ui/panels/disassembly/disassembly_tooltips.test.ts
+++ b/src/ui/panels/disassembly/disassembly_tooltips.test.ts
@@ -1,8 +1,17 @@
 import {
+  getAddressWrapMask,
   getMemoryOperation,
   getDisassemblyWriteValue,
+  formatIndexedAddressNotation,
+  formatPreIndexedAddressNotation,
+  formatMemoryTooltip,
   getDisassemblyTooltip as resolveDisassemblyTooltip,
+  getDisassemblyTooltipLines,
+  getDisassemblyTooltipMessages,
   getZeroPagePointer,
+  isolateTechnicalNotation,
+  joinDisassemblyTooltipLines,
+  renderDisassemblyTooltipMessages,
   DISASSEMBLY_TOOLTIP_ROWS,
 } from "./disassembly_tooltips"
 import { translateFromCatalogs } from "../../../i18n"
@@ -51,40 +60,107 @@ describe("disassembly tooltip table", () => {
     expect(pointer).toBe(0xC030)
   })
 
+  test("lets translations place invariant notation within complete memory tooltips", () => {
+    const selectedLanguage = {
+      disassembly: {
+        memory: {
+          effectiveAddress: "{{notation}} ← Adresse effective",
+          value: "{{notation}} ← Valeur",
+        },
+      },
+    }
+    const translate = (key: string, params?: Record<string, string>) =>
+      translateFromCatalogs(selectedLanguage, en, key, params)
+    const addressNotation = formatPreIndexedAddressNotation(
+      "$20", "$03", "$23", "$1234",
+    )
+    const indexedNotation = formatIndexedAddressNotation("$2000", "$03", "$2003")
+
+    expect(addressNotation).toBe("$1234 = ($23), $23 = $20 + $03")
+    expect(indexedNotation).toBe("$2003 = $2000 + $03")
+    expect(formatMemoryTooltip("effectiveAddress", indexedNotation, translateEnglish))
+      .toBe(`Effective address: ${isolateTechnicalNotation(indexedNotation)}`)
+    expect(formatMemoryTooltip("effectiveAddress", addressNotation, translate))
+      .toBe(`${isolateTechnicalNotation(addressNotation)} ← Adresse effective`)
+    expect(formatMemoryTooltip("value", "$42", translate))
+      .toBe(`${isolateTechnicalNotation("$42")} ← Valeur`)
+  })
+
+  test("makes wrapped indexed-address arithmetic explicit", () => {
+    expect(getAddressWrapMask(0xFE, 0x01, 0xFF)).toBeUndefined()
+    expect(getAddressWrapMask(0xFF, 0x02, 0xFF)).toBe("$FF")
+    expect(getAddressWrapMask(0xFFFE, 0x01, 0xFFFF)).toBeUndefined()
+    expect(getAddressWrapMask(0xFFFF, 0x01, 0xFFFF)).toBe("$FFFF")
+
+    expect(formatIndexedAddressNotation("$FF", "$02", "$01", "$FF"))
+      .toBe("$01 = ($FF + $02) & $FF")
+    expect(formatIndexedAddressNotation("$FFFF", "$01", "$0000", "$FFFF"))
+      .toBe("$0000 = ($FFFF + $01) & $FFFF")
+    expect(formatPreIndexedAddressNotation("$FF", "$02", "$01", "$C030", "$FF"))
+      .toBe("$C030 = ($01), $01 = ($FF + $02) & $FF")
+  })
+
+  test("isolates notation and renders each translated message on its own line", () => {
+    expect(isolateTechnicalNotation("$C073 = $C070 + $03"))
+      .toBe("\u2066$C073 = $C070 + $03\u2069")
+    expect(joinDisassemblyTooltipLines(
+      "Effective address: \u2066$C073 = $C070 + $03\u2069",
+      "Start paddle timers",
+      "Select auxiliary expansion bank $03 using RamWorks addressing",
+    )).toBe([
+      "Effective address: \u2066$C073 = $C070 + $03\u2069",
+      "Start paddle timers",
+      "Select auxiliary expansion bank $03 using RamWorks addressing",
+    ].join("\n"))
+  })
+
   test("distinguishes Apple IIe reads from writes in the keyboard/MMU range", () => {
     expect(getDisassemblyTooltip("APPLE2EE", 0xC003, "LDA", 0xDD))
-      .toBe("Keyboard = \"]\"; Strobe is SET (bit 7 = 1)")
+      .toBe("Keyboard: \"]\"\nKeyboard strobe: SET (MSB = 1)")
     expect(getDisassemblyTooltip("APPLE2EE", 0xC003, "STA", 0xDD))
       .toBe("Select auxiliary memory for reads")
   })
 
   test("treats the low Apple II+ range as keyboard mirrors", () => {
     expect(getDisassemblyTooltip("APPLE2P", 0xC003, "LDA", 0x5D))
-      .toBe("Keyboard = \"]\"; Strobe is CLEAR (bit 7 = 0)")
+      .toBe("Keyboard: \"]\"\nKeyboard strobe: CLEAR (MSB = 0)")
     expect(getDisassemblyTooltip("APPLE2P", 0xC003, "STA", 0x5D))
-      .toBe("Write ignored on Apple II+")
+      .toBe("INFO: This write has no effect on Apple II+")
     expect(getDisassemblyTooltip("APPLE2P", 0xC01A, "LDA", 0xF4))
       .toBe("Clear keyboard strobe")
     expect(getDisassemblyTooltip("APPLE2P", 0xC01A, "STA", 0xF4))
       .toBe("Clear keyboard strobe")
   })
 
-  test("decodes Apple IIe status from bit 7 without displaying bus bits", () => {
+  test("decodes Apple IIe status from the MSB without displaying bus bits", () => {
     expect(getDisassemblyTooltip("APPLE2EU", 0xC01A, "LDA", 0xF4))
-      .toBe("Text Mode = ON (bit 7 = 1)")
+      .toBe("Text mode: ON (MSB = 1)")
     expect(getDisassemblyTooltip("APPLE2EU", 0xC01A, "LDA", 0x74))
-      .toBe("Text Mode = OFF (bit 7 = 0)")
+      .toBe("Text mode: OFF (MSB = 0)")
     expect(getDisassemblyTooltip("APPLE2EU", 0xC01A, "STA", 0xF4))
       .toBe("Clear keyboard strobe")
     expect(getDisassemblyTooltip("APPLE2EU", 0xC019, "LDA", 0x00))
-      .toBe("Vertical Blank = ACTIVE (bit 7 = 0)")
+      .toBe("Vertical blank: ACTIVE (MSB = 0)")
     expect(getDisassemblyTooltip("APPLE2EU", 0xC019, "LDA", 0x80))
-      .toBe("Vertical Blank = INACTIVE (bit 7 = 1)")
+      .toBe("Vertical blank: INACTIVE (MSB = 1)")
+    expect(getDisassemblyTooltip("APPLE2EU", 0xC016, "LDA", 0x00))
+      .toBe("Zero page, stack, and bank-switched RAM: MAIN (MSB = 0)")
+    expect(getDisassemblyTooltip("APPLE2EU", 0xC016, "LDA", 0x80))
+      .toBe("Zero page, stack, and bank-switched RAM: AUXILIARY (MSB = 1)")
+    expect(getDisassemblyTooltip("APPLE2EU", 0xC018, "LDA", 0x80))
+      .toBe("PAGE2 selects main or auxiliary display memory (MSB = 1)")
+    expect(getDisassemblyTooltip("APPLE2EU", 0xC01C, "LDA", 0x00))
+      .toBe("Display-memory selection: PAGE 1 OR MAIN (MSB = 0)")
+    expect(getDisassemblyTooltip("APPLE2EU", 0xC01C, "LDA", 0x80))
+      .toBe("Display-memory selection: PAGE 2 OR AUXILIARY (MSB = 1)")
+    expect(getDisassemblyTooltipLines(
+      "APPLE2EU", 0xC01A, "LDA", -1, translateEnglish,
+    )).toEqual([])
   })
 
-  test("reports the any-key-down flag and clear-strobe action together", () => {
+  test("reports the any-key-down flag and clear-strobe action on separate lines", () => {
     expect(getDisassemblyTooltip("APPLE2EE", 0xC010, "LDA", 0x80))
-      .toBe("Any Key Down = YES (bit 7 = 1); Clear keyboard strobe")
+      .toBe("Any-key-down flag: SET (MSB = 1)\nClear keyboard strobe")
     expect(getDisassemblyTooltip("APPLE2EE", 0xC010, "STA", 0x80))
       .toBe("Clear keyboard strobe")
     expect(getDisassemblyTooltip("APPLE2P", 0xC010, "LDA", 0x80))
@@ -100,26 +176,54 @@ describe("disassembly tooltip table", () => {
       .toBe("Select graphics mode")
   })
 
-  test("supports reordered selected-language templates and English fallback", () => {
+  test("identifies the Apple2TS emulator register", () => {
+    expect(getDisassemblyTooltip("APPLE2EE", 0xC04F, "LDA", 0x00))
+      .toBe("INFO: Apple2TS emulator identifier: $CD")
+  })
+
+  test("renders complete switch-effect messages and parameterized data", () => {
+    expect(getDisassemblyTooltip("APPLE2EE", 0xC001, "STA", 0))
+      .toBe("Make PAGE2 select main or auxiliary display memory")
+    expect(getDisassemblyTooltip("APPLE2EE", 0xC006, "STA", 0))
+      .toBe("Select slot ROM for $C100-$CFFF")
+    expect(getDisassemblyTooltip("APPLE2EE", 0xC009, "STA", 0))
+      .toBe("Select auxiliary zero page, stack, and bank-switched RAM")
+    expect(getDisassemblyTooltip("APPLE2EE", 0xC00D, "STA", 0))
+      .toBe("Set display width to 80 columns")
+    expect(getDisassemblyTooltip("APPLE2EE", 0xC00F, "STA", 0))
+      .toBe("Select alternate character set")
+    expect(getDisassemblyTooltip("APPLE2EE", 0xC053, "STA", 0))
+      .toBe("Select mixed graphics/text")
+    expect(getDisassemblyTooltip("APPLE2P", 0xC055, "STA", 0))
+      .toBe("Select display page 2")
+    expect(getDisassemblyTooltip("APPLE2EE", 0xC055, "STA", 0))
+      .toBe("Select display page 2, or auxiliary display memory with 80STORE")
+    expect(getDisassemblyTooltip("APPLE2EE", 0xC057, "STA", 0))
+      .toBe("Select hi-res graphics")
+  })
+
+  test("supports localized complete clauses and English fallback", () => {
     const selectedLanguage = {
-      debug: {
-        disassemblyTooltips: {
-          formats: {
-            bit7: "bit {{bit}}: {{state}} ← {{label}}",
-            withAction: "{{action}} / {{status}}",
-          },
-          labels: {
-            textMode: "Modo texto",
-            anyKeyDown: "Tecla pulsada",
-          },
-          states: {
-            on: "ACTIVADO",
-            yes: "SÍ",
-          },
-          text: {
-            toggleSpeakerOutput: "Alternar salida del altavoz",
-            clearKeyboardStrobe: "Borrar indicador del teclado",
-          },
+      disassembly: {
+        display: {
+          selectGraphicsMode: "Cambiar a modo gráfico",
+          textModeStatusOn: "Modo texto: ACTIVADO (MSB = 1)",
+        },
+        languageCard: {
+          selectBank: "Tarjeta de lenguaje: Seleccionar banco {{bank}}",
+        },
+        keyboard: {
+          anyKeyDownSet: "Indicador de tecla pulsada: ACTIVO (MSB = 1)",
+          clearStrobe: "Borrar indicador del teclado",
+        },
+        transWarp: {
+          oneMhz: "TransWarp — Seleccionar 1 MHz",
+        },
+        notice: {
+          unknownWrite: "AVISO — Esta instrucción escribe un valor desconocido",
+        },
+        speaker: {
+          toggleOutput: "Alternar salida del altavoz",
         },
       },
     }
@@ -129,65 +233,193 @@ describe("disassembly tooltip table", () => {
     expect(resolveDisassemblyTooltip("APPLE2EE", 0xC030, "LDA", 0, translate))
       .toBe("Alternar salida del altavoz")
     expect(resolveDisassemblyTooltip("APPLE2EE", 0xC050, "LDA", 0, translate))
-      .toBe("Select graphics mode")
+      .toBe("Cambiar a modo gráfico")
     expect(resolveDisassemblyTooltip("APPLE2EE", 0xC01A, "LDA", 0x80, translate))
-      .toBe("bit 1: ACTIVADO ← Modo texto")
+      .toBe("Modo texto: ACTIVADO (MSB = 1)")
     expect(resolveDisassemblyTooltip("APPLE2EE", 0xC010, "LDA", 0x80, translate))
-      .toBe("Borrar indicador del teclado / bit 1: SÍ ← Tecla pulsada")
+      .toBe("Indicador de tecla pulsada: ACTIVO (MSB = 1)\nBorrar indicador del teclado")
+    expect(resolveDisassemblyTooltip("APPLE2EE", 0xC083, "LDA", 0, translate)
+      ?.split("\n")[0]).toBe("Tarjeta de lenguaje: Seleccionar banco 2")
+    expect(resolveDisassemblyTooltip("APPLE2EE", 0xC074, "STA", 0x01, translate)
+      ?.split("\n")[1]).toBe("TransWarp — Seleccionar 1 MHz")
+    expect(resolveDisassemblyTooltip("APPLE2EE", 0xC074, "INC", 0x7F, translate)
+      ?.split("\n")[1])
+      .toBe("AVISO — Esta instrucción escribe un valor desconocido")
   })
 
-  test("decodes input state from bit 7 only", () => {
+  test("resolves semantic messages before applying a language", () => {
+    const textModeMessages = getDisassemblyTooltipMessages("APPLE2EU", 0xC01A, "LDA", 0x80)
+    const auxiliaryBankMessages = getDisassemblyTooltipMessages(
+      "APPLE2EE", 0xC073, "STA", 0x0C,
+    )
+
+    expect(textModeMessages).toEqual([{key: "disassembly.display.textModeStatusOn"}])
+    expect(renderDisassemblyTooltipMessages(textModeMessages ?? [], translateEnglish))
+      .toEqual(["Text mode: ON (MSB = 1)"])
+    expect(auxiliaryBankMessages).toEqual([
+      {key: "disassembly.gameIO.startPaddleTimers"},
+      {
+        key: "disassembly.auxMemory.selectExpansionBank",
+        params: {bank: "$0C", addressing: "RamWorks"},
+      },
+    ])
+  })
+
+  test("decodes input state from the MSB only", () => {
     expect(getDisassemblyTooltip("APPLE2EE", 0xC061, "LDA", 0xFF))
-      .toBe("Pushbutton 0 = PRESSED (bit 7 = 1)")
+      .toBe("Pushbutton 0: PRESSED (MSB = 1)")
     expect(getDisassemblyTooltip("APPLE2EE", 0xC061, "LDA", 0x7F))
-      .toBe("Pushbutton 0 = RELEASED (bit 7 = 0)")
+      .toBe("Pushbutton 0: RELEASED (MSB = 0)")
+    expect(getDisassemblyTooltip("APPLE2EE", 0xC06D, "LDA", 0x80))
+      .toBe("Paddle 1 timer mirror: ACTIVE (MSB = 1)")
   })
 
-  test("keeps model-specific annunciator and double-hi-res meanings separate", () => {
+  test("separates model-specific annunciator and double-hi-res implications", () => {
     expect(getDisassemblyTooltip("APPLE2EE", 0xC05E, "LDA", 0))
-      .toBe("Disable annunciator 3; enable DHIRES")
+      .toBe("Disable annunciator 3\nEnable DHIRES")
     expect(getDisassemblyTooltip("APPLE2EE", 0xC05F, "STA", 0))
-      .toBe("Enable annunciator 3; disable DHIRES")
+      .toBe("Enable annunciator 3\nDisable DHIRES")
     expect(getDisassemblyTooltip("APPLE2P", 0xC05E, "LDA", 0))
       .toBe("Disable annunciator 3")
     expect(getDisassemblyTooltip("APPLE2P", 0xC05F, "STA", 0))
       .toBe("Enable annunciator 3")
   })
 
-  test.each(["APPLE2P", "APPLE2EU", "APPLE2EE"] as MACHINE_NAME[])(
-    "does not describe internal Video7 overrides as %s hardware addresses", machine => {
-      for (let address = 0xC078; address <= 0xC07D; address++) {
-        expect(getDisassemblyTooltip(machine, address, "LDA", 0)).toBeUndefined()
-        expect(getDisassemblyTooltip(machine, address, "STA", 0)).toBeUndefined()
+  test("describes the paddle trigger at every $C07x mirror", () => {
+    for (const machine of ["APPLE2P", "APPLE2EU", "APPLE2EE"] as const) {
+      for (let address = 0xC070; address <= 0xC07F; address++) {
+        expect(getDisassemblyTooltip(machine, address, "LDA", 0))
+          .toBe("Start paddle timers")
+        expect(getDisassemblyTooltip(machine, address, "STA", 0)?.split("\n")[0])
+          .toBe("Start paddle timers")
       }
-    },
-  )
-
-  test("describes auxiliary-bank addressing", () => {
-    expect(getDisassemblyTooltip("APPLE2EE", 0xC073, "LDA", 12)).toBe("")
-    expect(getDisassemblyTooltip("APPLE2EE", 0xC073, "STA", 12))
-      .toBe("Select auxiliary bank $0C using RamWorks addressing; start paddle timers")
-    expect(getDisassemblyTooltip("APPLE2EU", 0xC071, "STA", 1))
-      .toBe("Select auxiliary bank $01 using Neptune addressing; start paddle timers")
-    expect(getDisassemblyTooltip("APPLE2EE", 0xC073, "STA", 0))
-      .toBe("Select auxiliary bank $00 using RamWorks addressing; start paddle timers")
-    expect(getDisassemblyTooltip("APPLE2EE", 0xC073, "STA", -1))
-      .toBe("Select auxiliary bank using RamWorks addressing; start paddle timers")
-    expect(getDisassemblyTooltip("APPLE2P", 0xC073, "STA", 12)).toBeUndefined()
+    }
   })
 
-  test("distinguishes language-card read and write effects", () => {
+  test("separates auxiliary-bank addressing from the paddle-timer effect", () => {
+    expect(getDisassemblyTooltip("APPLE2EE", 0xC073, "LDA", 12))
+      .toBe("Start paddle timers")
+    expect(getDisassemblyTooltip("APPLE2EE", 0xC073, "STA", 12))
+      .toBe("Start paddle timers\nSelect auxiliary expansion bank $0C using RamWorks addressing")
+    expect(getDisassemblyTooltip("APPLE2EU", 0xC071, "STA", 1))
+      .toBe("Start paddle timers\nSelect auxiliary expansion bank $01 using Neptune addressing")
+    expect(getDisassemblyTooltip("APPLE2EE", 0xC073, "STA", 0))
+      .toBe("Start paddle timers\nSelect auxiliary expansion bank $00 using RamWorks addressing")
+    expect(getDisassemblyTooltip("APPLE2EE", 0xC073, "STA", -1))
+      .toBe("Start paddle timers")
+    expect(getDisassemblyTooltip("APPLE2P", 0xC073, "STA", 12))
+      .toBe("Start paddle timers")
+  })
+
+  test("decodes both documented $C074 accelerator-control conventions", () => {
+    expect(getDisassemblyTooltip("APPLE2EE", 0xC074, "LDA", 0xE0))
+      .toBe("Start paddle timers")
+    expect(getDisassemblyTooltip("APPLE2EE", 0xC074, "STA", 0x00)).toBe([
+      "Start paddle timers",
+      "TransWarp: Select configured maximum speed",
+      "Laser 128EX: Select 1 MHz maximum CPU speed",
+      "Laser 128EX: Disable automatic 1 MHz slowdown for port 7 disk access (write-once bit 5)",
+    ].join("\n"))
+    expect(getDisassemblyTooltip("APPLE2EE", 0xC074, "STA", 0x01)?.split("\n")[1])
+      .toBe("TransWarp: Select 1 MHz")
+    expect(getDisassemblyTooltip("APPLE2EE", 0xC074, "STA", 0x03)?.split("\n")[1])
+      .toBe("TransWarp: Disable acceleration until cold boot")
+    expect(getDisassemblyTooltip("APPLE2EE", 0xC074, "STA", 0x40)?.split("\n")[1])
+      .toBe("Laser 128EX: Select 1 MHz maximum CPU speed")
+    expect(getDisassemblyTooltip("APPLE2EE", 0xC074, "STA", 0xA0)).toBe([
+      "Start paddle timers",
+      "Laser 128EX: Select 2.3 MHz maximum CPU speed",
+      "Laser 128EX: Enable automatic 1 MHz slowdown for port 7 disk access (write-once bit 5)",
+    ].join("\n"))
+    expect(getDisassemblyTooltip("APPLE2EE", 0xC074, "STA", 0xC0)?.split("\n")[1])
+      .toBe("Laser 128EX: Select 3.6 MHz maximum CPU speed")
+    expect(getDisassemblyTooltip("APPLE2EE", 0xC074, "STA", -1))
+      .toBe("Start paddle timers")
+  })
+
+  test("classifies every Laser 128EX speed and disk-slowdown bit pattern", () => {
+    for (let value = 0; value <= 0xFF; value++) {
+      const lines = getDisassemblyTooltip("APPLE2EE", 0xC074, "STA", value)?.split("\n")
+      const speed = value < 0x80 ? "1 MHz" : value < 0xC0 ? "2.3 MHz" : "3.6 MHz"
+      const diskSlowdown = (value & 0x20) === 0 ? "Disable" : "Enable"
+
+      expect(lines).toContain(`Laser 128EX: Select ${speed} maximum CPU speed`)
+      expect(lines).toContain(
+        `Laser 128EX: ${diskSlowdown} automatic 1 MHz slowdown for port 7 disk access (write-once bit 5)`,
+      )
+      if (value !== 0 && value !== 1 && value !== 3) {
+        expect(lines?.some((line) => line.startsWith("TransWarp:"))).toBe(false)
+      }
+      expect(lines?.[0]).toBe("Start paddle timers")
+    }
+  })
+
+  test("separates each language-card implication", () => {
     expect(getDisassemblyTooltip("APPLE2P", 0xC083, "LDA", 0))
-      .toBe("Select LC bank 2; use RAM for reads; arm/enable writes")
+      .toBe([
+        "Language Card: Select bank 2",
+        "Language Card: Use RAM for reads",
+        "Language Card: Arm or enable writes",
+      ].join("\n"))
     expect(getDisassemblyTooltip("APPLE2P", 0xC083, "STA", 0))
-      .toBe("Select LC bank 2; use RAM for reads; reset prewrite latch")
+      .toBe([
+        "Language Card: Select bank 2",
+        "Language Card: Use RAM for reads",
+        "Language Card: Reset prewrite latch",
+      ].join("\n"))
+    expect(getDisassemblyTooltipLines(
+      "APPLE2P", 0xC083, "LDA", 0, translateEnglish,
+    )).toEqual([
+      "Language Card: Select bank 2",
+      "Language Card: Use RAM for reads",
+      "Language Card: Arm or enable writes",
+    ])
+    expect(getDisassemblyTooltipLines(
+      "APPLE2EE", 0xC083, "LDA", 0, translateEnglish,
+    )).toEqual([
+      "Language Card: Select bank 2",
+      "Language Card: Use RAM for reads",
+      "Language Card: Arm or enable writes",
+    ])
   })
 
   test("does not fall back to a raw value for known read-modify-write cases", () => {
     expect(getDisassemblyTooltip("APPLE2EE", 0xC030, "INC", 0x5D))
-      .toBe("Trigger multiple soft-switch operations")
+      .toBe("WARNING: This instruction triggers the soft switch multiple times")
     expect(getDisassemblyTooltip("APPLE2EE", 0xC030, "STA", 0x5D, "$C030,X"))
-      .toBe("Trigger multiple soft-switch operations")
+      .toBe("WARNING: This instruction triggers the soft switch multiple times")
+  })
+
+  test("preserves $C07x intent for indexed stores and read-modify-write accesses", () => {
+    expect(getDisassemblyTooltip("APPLE2EE", 0xC074, "STA", 0x01, "$C074,X")).toBe([
+      "Start paddle timers",
+      "WARNING: This instruction triggers the soft switch multiple times",
+      "TransWarp: Select 1 MHz",
+      "Laser 128EX: Select 1 MHz maximum CPU speed",
+      "Laser 128EX: Disable automatic 1 MHz slowdown for port 7 disk access (write-once bit 5)",
+    ].join("\n"))
+    expect(getDisassemblyTooltip("APPLE2EE", 0xC073, "STZ", 0x00, "$C073,X")).toBe([
+      "Start paddle timers",
+      "WARNING: This instruction triggers the soft switch multiple times",
+      "Select auxiliary expansion bank $00 using RamWorks addressing",
+    ].join("\n"))
+    expect(getDisassemblyTooltip("APPLE2EE", 0xC072, "INC", 0x7F)).toBe([
+      "Start paddle timers",
+    ].join("\n"))
+    expect(getDisassemblyTooltip("APPLE2EU", 0xC071, "INC", 0x7F)).toBe([
+      "Start paddle timers",
+      "WARNING: This instruction writes an unknown value",
+    ].join("\n"))
+    expect(getDisassemblyTooltip("APPLE2EE", 0xC073, "INC", 0x7F)).toBe([
+      "Start paddle timers",
+      "WARNING: This instruction writes an unknown value",
+    ].join("\n"))
+    expect(getDisassemblyTooltip("APPLE2P", 0xC073, "INC", 0x7F))
+      .toBe("Start paddle timers")
+    expect(getDisassemblyTooltip("APPLE2EE", 0xC074, "INC", 0x7F)).toBe([
+      "Start paddle timers",
+      "WARNING: This instruction writes an unknown value",
+    ].join("\n"))
   })
 
   test("returns undefined only for addresses outside the machine table", () => {

--- a/src/ui/panels/disassembly/disassembly_tooltips.ts
+++ b/src/ui/panels/disassembly/disassembly_tooltips.ts
@@ -1,29 +1,46 @@
 type MemoryOperation = "read" | "write" | "read-modify-write" | "multiple-access"
+type AddressWrapMask = "$FF" | "$FFFF"
 export type TooltipTranslator = (key: string, params?: Record<string, string>) => string
 
 type EnglishCatalog = (typeof import("../../../i18n/languages/en"))["en"]
-type TooltipCatalog = EnglishCatalog["debug"]["disassemblyTooltips"]
-type TooltipTextKey = keyof TooltipCatalog["text"]
-type TooltipLabelKey = keyof TooltipCatalog["labels"]
-type TooltipStateKey = keyof TooltipCatalog["states"]
-export type TooltipFormatKey = keyof TooltipCatalog["formats"]
+type TooltipCatalog = EnglishCatalog["disassembly"]
+type TooltipGroup = {
+  [Key in keyof TooltipCatalog]: TooltipCatalog[Key] extends Record<string, string>
+    ? Key
+    : never
+}[keyof TooltipCatalog]
+type TooltipGroupedKey = {
+  [Group in TooltipGroup]:
+    `${Extract<Group, string>}.${Extract<keyof TooltipCatalog[Group], string>}`
+}[TooltipGroup]
+type TooltipGroupedMessageKey<Group extends TooltipGroup> =
+  Group extends TooltipGroup
+    ? Extract<keyof TooltipCatalog[Group], string>
+    : never
 
-const tooltipKey = <Group extends keyof TooltipCatalog>(
-  group: Group,
-  key: Extract<keyof TooltipCatalog[Group], string>,
-) => `debug.disassemblyTooltips.${group}.${key}`
+type TooltipGroupedMessagePath = `disassembly.${TooltipGroupedKey}`
+export type DisassemblyMessageKey = TooltipGroupedMessagePath
+export type DisassemblyTooltipMessage = {
+  key: DisassemblyMessageKey
+  params?: Record<string, string>
+}
+type TooltipGroupedMessageDescriptor<Group extends TooltipGroup> = {
+  kind: "grouped-message"
+  group: Group
+  key: TooltipGroupedMessageKey<Group>
+  params?: Record<string, string>
+}
+type AnyTooltipGroupedMessageDescriptor = {
+  [Group in TooltipGroup]: TooltipGroupedMessageDescriptor<Group>
+}[TooltipGroup]
 
 type TooltipDescriptor =
-  | {kind: "text", key: TooltipTextKey}
-  | {
-    kind: "bit7"
-    labelKey: TooltipLabelKey
-    clearKey: TooltipStateKey
-    setKey: TooltipStateKey
-    actionKey?: TooltipTextKey
-  }
+  | AnyTooltipGroupedMessageDescriptor
+  | {kind: "sequence", parts: readonly TooltipDescriptor[]}
+  | {kind: "msb-choice", zero: TooltipDescriptor, one: TooltipDescriptor}
   | {kind: "keyboard"}
   | {kind: "aux-bank-selector", addressing: string}
+  | {kind: "accelerator-control"}
 
 type DisassemblyTooltipRow = {
   machines: readonly MACHINE_NAME[]
@@ -43,17 +60,61 @@ const ALL_MACHINES: readonly MACHINE_NAME[] = ["APPLE2P", "APPLE2EU", "APPLE2EE"
 const APPLE2EX: readonly MACHINE_NAME[] = ["APPLE2EU", "APPLE2EE"]
 const APPLE2P: readonly MACHINE_NAME[] = ["APPLE2P"]
 
-const text = (key: TooltipTextKey): TooltipDescriptor => ({kind: "text", key})
-const bit7 = (
-  labelKey: TooltipLabelKey,
-  clearKey: TooltipStateKey,
-  setKey: TooltipStateKey,
-  actionKey?: TooltipTextKey,
-): TooltipDescriptor =>
-  ({kind: "bit7", labelKey, clearKey, setKey, actionKey})
+const sequence = (...parts: readonly TooltipDescriptor[]): TooltipDescriptor =>
+  ({kind: "sequence", parts})
 const keyboard = (): TooltipDescriptor => ({kind: "keyboard"})
 const auxiliaryBankSelector = (addressing: string): TooltipDescriptor =>
   ({kind: "aux-bank-selector", addressing})
+const acceleratorControl = (): TooltipDescriptor => ({kind: "accelerator-control"})
+const groupedMessage = <Group extends TooltipGroup>(
+  group: Group,
+  key: TooltipGroupedMessageKey<Group>,
+  params?: Record<string, string>,
+): TooltipGroupedMessageDescriptor<Group> => ({kind: "grouped-message", group, key, params})
+const msbMessages = <Group extends TooltipGroup>(
+  group: Group,
+  zero: TooltipGroupedMessageKey<Group>,
+  one: TooltipGroupedMessageKey<Group>,
+  params?: Record<string, string>,
+): TooltipDescriptor => ({
+  kind: "msb-choice",
+  zero: groupedMessage(group, zero, params) as AnyTooltipGroupedMessageDescriptor,
+  one: groupedMessage(group, one, params) as AnyTooltipGroupedMessageDescriptor,
+})
+const setAnnunciator = (
+  number: "0" | "1" | "2" | "3",
+  action: "disable" | "enable",
+): TooltipDescriptor => groupedMessage("annunciator", action, {
+  number,
+})
+const setDisplayWidth = (columns: "40" | "80"): TooltipDescriptor =>
+  groupedMessage("display", "setWidth", {columns})
+const selectRomForRange = (
+  source: "internal" | "slot",
+  range: string,
+): TooltipDescriptor => groupedMessage(
+  "rom",
+  source,
+  {range},
+)
+type LanguageCardWriteMode = "disable-writes" | "reset-prewrite-latch" | "arm-or-enable-writes"
+const LANGUAGE_CARD_WRITE_KEYS: Record<
+  LanguageCardWriteMode,
+  TooltipGroupedMessageKey<"languageCard">
+> = {
+  "disable-writes": "disableWrites",
+  "reset-prewrite-latch": "resetPrewriteLatch",
+  "arm-or-enable-writes": "armOrEnableWrites",
+}
+const languageCard = (
+  bank: "1" | "2",
+  readSource: "ram" | "rom",
+  writeMode: LanguageCardWriteMode,
+): TooltipDescriptor => sequence(
+  groupedMessage("languageCard", "selectBank", {bank}),
+  groupedMessage("languageCard", readSource === "ram" ? "useRamForReads" : "useRomForReads"),
+  groupedMessage("languageCard", LANGUAGE_CARD_WRITE_KEYS[writeMode]),
+)
 
 const addressRange = (start: number, end: number) =>
   Array.from({length: end - start + 1}, (_, offset) => start + offset)
@@ -64,13 +125,56 @@ const define = (
   descriptors: Omit<DisassemblyTooltipRow, "machines" | "address">,
 ): DisassemblyTooltipDefinition => ({machines, addresses, ...descriptors})
 
+const LANGUAGE_CARD_SWITCHES = [
+  [0xC080, "2", "ram", "disable-writes"],
+  [0xC081, "2", "rom", "arm-or-enable-writes"],
+  [0xC082, "2", "rom", "disable-writes"],
+  [0xC083, "2", "ram", "arm-or-enable-writes"],
+  [0xC084, "2", "ram", "disable-writes"],
+  [0xC085, "2", "rom", "arm-or-enable-writes"],
+  [0xC086, "2", "rom", "disable-writes"],
+  [0xC087, "2", "ram", "arm-or-enable-writes"],
+  [0xC088, "1", "ram", "disable-writes"],
+  [0xC089, "1", "rom", "arm-or-enable-writes"],
+  [0xC08A, "1", "rom", "disable-writes"],
+  [0xC08B, "1", "ram", "arm-or-enable-writes"],
+  [0xC08C, "1", "ram", "disable-writes"],
+  [0xC08D, "1", "rom", "arm-or-enable-writes"],
+  [0xC08E, "1", "rom", "disable-writes"],
+  [0xC08F, "1", "ram", "arm-or-enable-writes"],
+] as const satisfies readonly (readonly [number, "1" | "2", "ram" | "rom", LanguageCardWriteMode])[]
+
+const defineLanguageCardSwitches = (
+  machines: readonly MACHINE_NAME[],
+): readonly DisassemblyTooltipDefinition[] => LANGUAGE_CARD_SWITCHES.map(([
+  address, bank, readSource, readAccessWriteMode,
+]) => ({
+  machines,
+  address,
+  read: languageCard(bank, readSource, readAccessWriteMode),
+  write: languageCard(bank, readSource, "reset-prewrite-latch"),
+}))
+
 // These shared descriptors are intentionally one semantic source for every
 // matching address.
 const KEYBOARD_READ = keyboard()
-const CLEAR_KEYBOARD_STROBE = text("clearKeyboardStrobe")
-const WRITE_IGNORED_ON_APPLE2P = text("writeIgnoredOnAppleIiPlus")
-const NEPTUNE_AUX_BANK_SELECTOR = auxiliaryBankSelector("Neptune")
-const RAMWORKS_AUX_BANK_SELECTOR = auxiliaryBankSelector("RamWorks")
+const CLEAR_KEYBOARD_STROBE = groupedMessage("keyboard", "clearStrobe")
+const NO_WRITE_EFFECT_ON_APPLE2P = groupedMessage("notice", "noWriteEffect", {
+  machine: "Apple II+",
+})
+const PADDLE_TRIGGER = groupedMessage("gameIO", "startPaddleTimers")
+const NEPTUNE_AUX_BANK_SELECTOR = sequence(
+  PADDLE_TRIGGER,
+  auxiliaryBankSelector("Neptune"),
+)
+const RAMWORKS_AUX_BANK_SELECTOR = sequence(
+  PADDLE_TRIGGER,
+  auxiliaryBankSelector("RamWorks"),
+)
+const ACCELERATOR_CONTROL = sequence(
+  PADDLE_TRIGGER,
+  acceleratorControl(),
+)
 
 const expandDefinitions = (
   definitions: readonly DisassemblyTooltipDefinition[],
@@ -102,32 +206,35 @@ const expandDefinitions = (
 const DISASSEMBLY_TOOLTIP_DEFINITIONS: readonly DisassemblyTooltipDefinition[] = [
   // Apple IIe keyboard reads and write-only memory switches.
   define(APPLE2EX, addressRange(0xC000, 0xC00F), {read: KEYBOARD_READ}),
-  define(APPLE2EX, addresses(0xC000), {write: text("disablePage2DisplayMemoryBanking")}),
-  define(APPLE2EX, addresses(0xC001), {write: text("enablePage2DisplayMemoryBanking")}),
-  define(APPLE2EX, addresses(0xC002), {write: text("selectMainMemoryForReads")}),
-  define(APPLE2EX, addresses(0xC003), {write: text("selectAuxiliaryMemoryForReads")}),
-  define(APPLE2EX, addresses(0xC004), {write: text("selectMainMemoryForWrites")}),
-  define(APPLE2EX, addresses(0xC005), {write: text("selectAuxiliaryMemoryForWrites")}),
-  define(APPLE2EX, addresses(0xC006), {write: text("selectSlotRomForC100Cfff")}),
-  define(APPLE2EX, addresses(0xC007), {write: text("selectInternalRomForC100Cfff")}),
-  define(APPLE2EX, addresses(0xC008), {write: text("selectMainZeroPageAndStack")}),
-  define(APPLE2EX, addresses(0xC009), {write: text("selectAuxiliaryZeroPageAndStack")}),
-  define(APPLE2EX, addresses(0xC00A), {write: text("selectInternalRomForC300C3ff")}),
-  define(APPLE2EX, addresses(0xC00B), {write: text("selectSlot3Rom")}),
-  define(APPLE2EX, addresses(0xC00C), {write: text("select40ColumnDisplay")}),
-  define(APPLE2EX, addresses(0xC00D), {write: text("select80ColumnDisplay")}),
-  define(APPLE2EX, addresses(0xC00E), {write: text("selectPrimaryCharacterSet")}),
-  define(APPLE2EX, addresses(0xC00F), {write: text("selectAlternateCharacterSet")}),
+  define(APPLE2EX, addresses(0xC000), {write: groupedMessage("displayMemory", "80storeOff")}),
+  define(APPLE2EX, addresses(0xC001), {write: groupedMessage("displayMemory", "80storeOn")}),
+  define(APPLE2EX, addresses(0xC002), {write: groupedMessage("auxMemory", "readMain")}),
+  define(APPLE2EX, addresses(0xC003), {write: groupedMessage("auxMemory", "readAuxiliary")}),
+  define(APPLE2EX, addresses(0xC004), {write: groupedMessage("auxMemory", "writeMain")}),
+  define(APPLE2EX, addresses(0xC005), {write: groupedMessage("auxMemory", "writeAuxiliary")}),
+  define(APPLE2EX, addresses(0xC006), {write: selectRomForRange("slot", "$C100-$CFFF")}),
+  define(APPLE2EX, addresses(0xC007), {write: selectRomForRange("internal", "$C100-$CFFF")}),
+  define(APPLE2EX, addresses(0xC008), {write: groupedMessage("auxMemory", "altzpMain")}),
+  define(APPLE2EX, addresses(0xC009), {write: groupedMessage("auxMemory", "altzpAuxiliary")}),
+  define(APPLE2EX, addresses(0xC00A), {write: selectRomForRange("internal", "$C300-$C3FF")}),
+  define(APPLE2EX, addresses(0xC00B), {write: selectRomForRange("slot", "$C300-$C3FF")}),
+  define(APPLE2EX, addresses(0xC00C), {write: setDisplayWidth("40")}),
+  define(APPLE2EX, addresses(0xC00D), {write: setDisplayWidth("80")}),
+  define(APPLE2EX, addresses(0xC00E), {write: groupedMessage("display", "selectPrimaryCharset")}),
+  define(APPLE2EX, addresses(0xC00F), {write: groupedMessage("display", "selectAlternateCharset")}),
 
   // On the Apple II+, $C000-$C00F are keyboard mirrors rather than IIe
   // memory-management switches. Writes are ignored.
   define(APPLE2P, addressRange(0xC000, 0xC00F), {
     read: KEYBOARD_READ,
-    write: WRITE_IGNORED_ON_APPLE2P,
+    write: NO_WRITE_EFFECT_ON_APPLE2P,
   }),
 
   define(APPLE2EX, addresses(0xC010), {
-    read: bit7("anyKeyDown", "no", "yes", "clearKeyboardStrobe"),
+    read: sequence(
+      msbMessages("keyboard", "anyKeyDownClear", "anyKeyDownSet"),
+      CLEAR_KEYBOARD_STROBE,
+    ),
     write: CLEAR_KEYBOARD_STROBE,
   }),
   define(APPLE2P, addresses(0xC010), {access: CLEAR_KEYBOARD_STROBE}),
@@ -142,176 +249,151 @@ const DISASSEMBLY_TOOLTIP_DEFINITIONS: readonly DisassemblyTooltipDefinition[] =
   // Apple IIe status reads. Writes in this range clear the keyboard strobe.
   define(APPLE2EX, addressRange(0xC011, 0xC01F), {write: CLEAR_KEYBOARD_STROBE}),
   {machines: APPLE2EX, address: 0xC011,
-    read: bit7("languageCardBank", "1", "2")},
+    read: msbMessages("languageCard", "bank1", "bank2")},
   {machines: APPLE2EX, address: 0xC012,
-    read: bit7("languageCardReadSource", "rom", "ram")},
+    read: msbMessages("languageCard", "readSourceRom", "readSourceRam")},
   {machines: APPLE2EX, address: 0xC013,
-    read: bit7("auxiliaryMemoryReads", "off", "on")},
+    read: msbMessages("auxMemory", "readStatusOff", "readStatusOn")},
   {machines: APPLE2EX, address: 0xC014,
-    read: bit7("auxiliaryMemoryWrites", "off", "on")},
+    read: msbMessages("auxMemory", "writeStatusOff", "writeStatusOn")},
   {machines: APPLE2EX, address: 0xC015,
-    read: bit7("internalCxRom", "off", "on")},
+    read: msbMessages("rom", "intCxOff", "intCxOn")},
   {machines: APPLE2EX, address: 0xC016,
-    read: bit7("auxiliaryZeroPageAndStack", "off", "on")},
+    read: msbMessages("auxMemory", "altzpStatusMain", "altzpStatusAuxiliary")},
   {machines: APPLE2EX, address: 0xC017,
-    read: bit7("slot3Rom", "off", "on")},
+    read: msbMessages("rom", "slot3Off", "slot3On")},
   {machines: APPLE2EX, address: 0xC018,
-    read: bit7("page2DisplayMemoryBanking", "off", "on")},
+    read: msbMessages("displayMemory", "80storeStatusOff", "80storeStatusOn")},
   {machines: APPLE2EX, address: 0xC019,
-    read: bit7("verticalBlank", "active", "inactive")},
+    read: msbMessages("display", "verticalBlankActive", "verticalBlankInactive")},
   {machines: APPLE2EX, address: 0xC01A,
-    read: bit7("textMode", "off", "on")},
+    read: msbMessages("display", "textModeStatusOff", "textModeStatusOn")},
   {machines: APPLE2EX, address: 0xC01B,
-    read: bit7("mixedDisplay", "off", "on")},
+    read: msbMessages("display", "mixedDisplayStatusOff", "mixedDisplayStatusOn")},
   {machines: APPLE2EX, address: 0xC01C,
-    read: bit7("displayPage", "1", "2")},
+    read: msbMessages("displayMemory", "page2StatusClear", "page2StatusSet")},
   {machines: APPLE2EX, address: 0xC01D,
-    read: bit7("hiResMode", "off", "on")},
+    read: msbMessages("display", "hiresModeStatusOff", "hiresModeStatusOn")},
   {machines: APPLE2EX, address: 0xC01E,
-    read: bit7("alternateCharacterSet", "off", "on")},
+    read: msbMessages("display", "altCharsetStatusOff", "altCharsetStatusOn")},
   {machines: APPLE2EX, address: 0xC01F,
-    read: bit7("80ColumnDisplay", "off", "on")},
+    read: msbMessages("display", "column80StatusOff", "column80StatusOn")},
 
   {machines: ALL_MACHINES, address: 0xC020,
-    access: text("toggleCassetteOutput")},
+    access: groupedMessage("cassette", "toggleOutput")},
   {machines: ALL_MACHINES, address: 0xC030,
-    access: text("toggleSpeakerOutput")},
+    access: groupedMessage("speaker", "toggleOutput")},
   {machines: ALL_MACHINES, address: 0xC040,
-    access: text("pulseGamePortStrobe")},
+    access: groupedMessage("gameIO", "pulseStrobe")},
   {machines: ALL_MACHINES, address: 0xC04F,
-    access: text("apple2tsEmulationMarkerAlwaysCd")},
+    access: groupedMessage("notice", "emulatorIdentifier")},
 
   // Display and annunciator action switches.
   {machines: ALL_MACHINES, address: 0xC050,
-    access: text("selectGraphicsMode")},
+    access: groupedMessage("display", "selectGraphicsMode")},
   {machines: ALL_MACHINES, address: 0xC051,
-    access: text("selectTextMode")},
+    access: groupedMessage("display", "selectTextMode")},
   {machines: ALL_MACHINES, address: 0xC052,
-    access: text("selectFullScreenDisplay")},
+    access: groupedMessage("display", "selectFullScreenDisplay")},
   {machines: ALL_MACHINES, address: 0xC053,
-    access: text("selectMixedGraphicsText")},
-  {machines: ALL_MACHINES, address: 0xC054,
-    access: text("selectDisplayPage1")},
-  {machines: ALL_MACHINES, address: 0xC055,
-    access: text("selectDisplayPage2")},
+    access: groupedMessage("display", "selectMixedDisplay")},
+  {machines: APPLE2P, address: 0xC054,
+    access: groupedMessage("displayMemory", "selectPage1")},
+  {machines: APPLE2EX, address: 0xC054,
+    access: groupedMessage("displayMemory", "page2Clear")},
+  {machines: APPLE2P, address: 0xC055,
+    access: groupedMessage("displayMemory", "selectPage2")},
+  {machines: APPLE2EX, address: 0xC055,
+    access: groupedMessage("displayMemory", "page2Set")},
   {machines: ALL_MACHINES, address: 0xC056,
-    access: text("selectLoResGraphics")},
+    access: groupedMessage("display", "selectLoresGraphics")},
   {machines: ALL_MACHINES, address: 0xC057,
-    access: text("selectHiResGraphics")},
+    access: groupedMessage("display", "selectHiresGraphics")},
   {machines: ALL_MACHINES, address: 0xC058,
-    access: text("disableAnnunciator0")},
+    access: setAnnunciator("0", "disable")},
   {machines: ALL_MACHINES, address: 0xC059,
-    access: text("enableAnnunciator0")},
+    access: setAnnunciator("0", "enable")},
   {machines: ALL_MACHINES, address: 0xC05A,
-    access: text("disableAnnunciator1")},
+    access: setAnnunciator("1", "disable")},
   {machines: ALL_MACHINES, address: 0xC05B,
-    access: text("enableAnnunciator1")},
+    access: setAnnunciator("1", "enable")},
   {machines: ALL_MACHINES, address: 0xC05C,
-    access: text("disableAnnunciator2")},
+    access: setAnnunciator("2", "disable")},
   {machines: ALL_MACHINES, address: 0xC05D,
-    access: text("enableAnnunciator2")},
+    access: setAnnunciator("2", "enable")},
   {machines: APPLE2EX, address: 0xC05E,
-    access: text("disableAnnunciator3EnableDhires")},
+    access: sequence(setAnnunciator("3", "disable"), groupedMessage("display", "enableDhires"))},
   {machines: APPLE2EX, address: 0xC05F,
-    access: text("enableAnnunciator3DisableDhires")},
+    access: sequence(setAnnunciator("3", "enable"), groupedMessage("display", "disableDhires"))},
   {machines: APPLE2P, address: 0xC05E,
-    access: text("disableAnnunciator3")},
+    access: setAnnunciator("3", "disable")},
   {machines: APPLE2P, address: 0xC05F,
-    access: text("enableAnnunciator3")},
+    access: setAnnunciator("3", "enable")},
 
   // Inputs. Writes have no useful state to display, so their matched cells are
   // intentionally empty and suppress the generic raw-byte tooltip.
   {machines: ALL_MACHINES, address: 0xC060,
-    read: text("sampleCassetteInput")},
+    read: groupedMessage("cassette", "sampleInput")},
   {machines: ALL_MACHINES, address: 0xC061,
-    read: bit7("pushbutton0", "released", "pressed")},
+    read: msbMessages("gameIO", "buttonReleased", "buttonPressed", {number: "0"})},
   {machines: ALL_MACHINES, address: 0xC062,
-    read: bit7("pushbutton1", "released", "pressed")},
+    read: msbMessages("gameIO", "buttonReleased", "buttonPressed", {number: "1"})},
   {machines: ALL_MACHINES, address: 0xC063,
-    read: bit7("pushbutton2", "released", "pressed")},
+    read: msbMessages("gameIO", "buttonReleased", "buttonPressed", {number: "2"})},
   {machines: ALL_MACHINES, address: 0xC064,
-    read: bit7("paddle0Timer", "expired", "active")},
+    read: msbMessages("gameIO", "paddleExpired", "paddleActive", {number: "0"})},
   {machines: ALL_MACHINES, address: 0xC065,
-    read: bit7("paddle1Timer", "expired", "active")},
+    read: msbMessages("gameIO", "paddleExpired", "paddleActive", {number: "1"})},
   {machines: ALL_MACHINES, address: 0xC066,
-    read: bit7("paddle2Timer", "expired", "active")},
+    read: msbMessages("gameIO", "paddleExpired", "paddleActive", {number: "2"})},
   {machines: ALL_MACHINES, address: 0xC067,
-    read: bit7("paddle3Timer", "expired", "active")},
+    read: msbMessages("gameIO", "paddleExpired", "paddleActive", {number: "3"})},
   {machines: ALL_MACHINES, address: 0xC068,
-    read: text("sampleCassetteInputMirror")},
+    read: groupedMessage("cassette", "sampleInputMirror")},
   {machines: ALL_MACHINES, address: 0xC069,
-    read: bit7("pushbutton0Mirror", "released", "pressed")},
+    read: msbMessages(
+      "gameIO", "buttonMirrorReleased", "buttonMirrorPressed", {number: "0"},
+    )},
   {machines: ALL_MACHINES, address: 0xC06A,
-    read: bit7("pushbutton1Mirror", "released", "pressed")},
+    read: msbMessages(
+      "gameIO", "buttonMirrorReleased", "buttonMirrorPressed", {number: "1"},
+    )},
   {machines: ALL_MACHINES, address: 0xC06B,
-    read: bit7("pushbutton2Mirror", "released", "pressed")},
+    read: msbMessages(
+      "gameIO", "buttonMirrorReleased", "buttonMirrorPressed", {number: "2"},
+    )},
   {machines: ALL_MACHINES, address: 0xC06C,
-    read: bit7("paddle0TimerMirror", "expired", "active")},
+    read: msbMessages(
+      "gameIO", "paddleMirrorExpired", "paddleMirrorActive", {number: "0"},
+    )},
   {machines: ALL_MACHINES, address: 0xC06D,
-    read: bit7("paddle1TimerMirror", "expired", "active")},
+    read: msbMessages(
+      "gameIO", "paddleMirrorExpired", "paddleMirrorActive", {number: "1"},
+    )},
   {machines: ALL_MACHINES, address: 0xC06E,
-    read: bit7("paddle2TimerMirror", "expired", "active")},
+    read: msbMessages(
+      "gameIO", "paddleMirrorExpired", "paddleMirrorActive", {number: "2"},
+    )},
   {machines: ALL_MACHINES, address: 0xC06F,
-    read: bit7("paddle3TimerMirror", "expired", "active")},
-  {machines: ALL_MACHINES, address: 0xC070,
-    access: text("startPaddleTimers")},
+    read: msbMessages(
+      "gameIO", "paddleMirrorExpired", "paddleMirrorActive", {number: "3"},
+    )},
+  // The motherboard decodes every read and write in $C070-$C07F as a
+  // paddle trigger. A card or clone may add another effect without replacing
+  // this base Apple II behavior.
+  define(ALL_MACHINES, addressRange(0xC070, 0xC07F), {access: PADDLE_TRIGGER}),
 
   // Auxiliary-card conventions. The instruction tells us the convention and
   // requested bank byte, not whether a configured device accepts it.
   define(APPLE2EX, addresses(0xC071), {write: NEPTUNE_AUX_BANK_SELECTOR}),
   define(APPLE2EX, addresses(0xC073), {write: RAMWORKS_AUX_BANK_SELECTOR}),
-  {machines: ALL_MACHINES, address: 0xC074,
-    access: text("laser128exCompatibilityNotEmulated")},
-  // Language Card switches. Odd reads arm and then enable writes; writes reset
-  // the prewrite latch but otherwise preserve the current write-enable state.
-  {machines: ALL_MACHINES, address: 0xC080,
-    read: text("selectLcBank2UseRamForReadsDisableWrites"),
-    write: text("selectLcBank2UseRamForReadsResetPrewriteLatch")},
-  {machines: ALL_MACHINES, address: 0xC081,
-    read: text("selectLcBank2UseRomForReadsArmEnableWrites"),
-    write: text("selectLcBank2UseRomForReadsResetPrewriteLatch")},
-  {machines: ALL_MACHINES, address: 0xC082,
-    read: text("selectLcBank2UseRomForReadsDisableWrites"),
-    write: text("selectLcBank2UseRomForReadsResetPrewriteLatch")},
-  {machines: ALL_MACHINES, address: 0xC083,
-    read: text("selectLcBank2UseRamForReadsArmEnableWrites"),
-    write: text("selectLcBank2UseRamForReadsResetPrewriteLatch")},
-  {machines: ALL_MACHINES, address: 0xC084,
-    read: text("selectLcBank2UseRamForReadsDisableWrites"),
-    write: text("selectLcBank2UseRamForReadsResetPrewriteLatch")},
-  {machines: ALL_MACHINES, address: 0xC085,
-    read: text("selectLcBank2UseRomForReadsArmEnableWrites"),
-    write: text("selectLcBank2UseRomForReadsResetPrewriteLatch")},
-  {machines: ALL_MACHINES, address: 0xC086,
-    read: text("selectLcBank2UseRomForReadsDisableWrites"),
-    write: text("selectLcBank2UseRomForReadsResetPrewriteLatch")},
-  {machines: ALL_MACHINES, address: 0xC087,
-    read: text("selectLcBank2UseRamForReadsArmEnableWrites"),
-    write: text("selectLcBank2UseRamForReadsResetPrewriteLatch")},
-  {machines: ALL_MACHINES, address: 0xC088,
-    read: text("selectLcBank1UseRamForReadsDisableWrites"),
-    write: text("selectLcBank1UseRamForReadsResetPrewriteLatch")},
-  {machines: ALL_MACHINES, address: 0xC089,
-    read: text("selectLcBank1UseRomForReadsArmEnableWrites"),
-    write: text("selectLcBank1UseRomForReadsResetPrewriteLatch")},
-  {machines: ALL_MACHINES, address: 0xC08A,
-    read: text("selectLcBank1UseRomForReadsDisableWrites"),
-    write: text("selectLcBank1UseRomForReadsResetPrewriteLatch")},
-  {machines: ALL_MACHINES, address: 0xC08B,
-    read: text("selectLcBank1UseRamForReadsArmEnableWrites"),
-    write: text("selectLcBank1UseRamForReadsResetPrewriteLatch")},
-  {machines: ALL_MACHINES, address: 0xC08C,
-    read: text("selectLcBank1UseRamForReadsDisableWrites"),
-    write: text("selectLcBank1UseRamForReadsResetPrewriteLatch")},
-  {machines: ALL_MACHINES, address: 0xC08D,
-    read: text("selectLcBank1UseRomForReadsArmEnableWrites"),
-    write: text("selectLcBank1UseRomForReadsResetPrewriteLatch")},
-  {machines: ALL_MACHINES, address: 0xC08E,
-    read: text("selectLcBank1UseRomForReadsDisableWrites"),
-    write: text("selectLcBank1UseRomForReadsResetPrewriteLatch")},
-  {machines: ALL_MACHINES, address: 0xC08F,
-    read: text("selectLcBank1UseRamForReadsArmEnableWrites"),
-    write: text("selectLcBank1UseRamForReadsResetPrewriteLatch")},
+  define(ALL_MACHINES, addresses(0xC074), {write: ACCELERATOR_CONTROL}),
+  // Slot 0 supplies an optional Language Card on the II+. Equivalent bank-
+  // switched memory is built into the IIe motherboard. Odd reads arm and then
+  // enable writes; writes reset the prewrite latch but otherwise preserve the
+  // current write-enable state.
+  ...defineLanguageCardSwitches(APPLE2P),
+  ...defineLanguageCardSwitches(APPLE2EX),
 ]
 
 export const DISASSEMBLY_TOOLTIP_ROWS = expandDefinitions(DISASSEMBLY_TOOLTIP_DEFINITIONS)
@@ -365,6 +447,49 @@ export const getZeroPagePointer = (
   return readByte(lowAddress) + 256 * readByte((lowAddress + 1) & 0xFF)
 }
 
+export const formatPreIndexedAddressNotation = (
+  base: string,
+  index: string,
+  pointer: string,
+  effectiveAddress: string,
+  wrapMask?: AddressWrapMask,
+) => `${effectiveAddress} = (${pointer}), ${pointer} = ${wrapMask
+  ? `(${base} + ${index}) & ${wrapMask}`
+  : `${base} + ${index}`}`
+
+export const formatIndexedAddressNotation = (
+  base: string,
+  index: string,
+  effectiveAddress: string,
+  wrapMask?: AddressWrapMask,
+) => `${effectiveAddress} = ${wrapMask
+  ? `(${base} + ${index}) & ${wrapMask}`
+  : `${base} + ${index}`}`
+
+export const getAddressWrapMask = (
+  base: number,
+  index: number,
+  mask: 0xFF | 0xFFFF,
+) => base + index > mask ? (mask === 0xFF ? "$FF" : "$FFFF") : undefined
+
+const LEFT_TO_RIGHT_ISOLATE = "\u2066"
+const POP_DIRECTIONAL_ISOLATE = "\u2069"
+
+export const isolateTechnicalNotation = (notation: string) =>
+  `${LEFT_TO_RIGHT_ISOLATE}${notation}${POP_DIRECTIONAL_ISOLATE}`
+
+export const formatMemoryTooltip = (
+  kind: TooltipGroupedMessageKey<"memory">,
+  notation: string,
+  translate: TooltipTranslator,
+) => translate(`disassembly.memory.${kind}`, {
+  notation: isolateTechnicalNotation(notation),
+})
+
+export const joinDisassemblyTooltipLines = (
+  ...lines: readonly (string | undefined)[]
+) => lines.filter(Boolean).join("\n")
+
 const formatKeyboardCharacter = (value: number) => {
   const key = value & 0x7F
   if (key === 0x7F) return "DEL"
@@ -374,57 +499,147 @@ const formatKeyboardCharacter = (value: number) => {
   return String.fromCharCode(key)
 }
 
-const formatDescriptor = (
+const groupedTooltipMessage = <Group extends TooltipGroup>(
+  group: Group,
+  key: TooltipGroupedMessageKey<Group>,
+  params?: Record<string, string>,
+): DisassemblyTooltipMessage => ({
+  key: `disassembly.${group}.${key}` as TooltipGroupedMessagePath,
+  ...(params ? {params} : {}),
+})
+const warningMessage = (
+  key: "multipleTriggers" | "unknownWrite",
+): DisassemblyTooltipMessage => groupedTooltipMessage("notice", key)
+
+export const renderDisassemblyTooltipMessages = (
+  messages: readonly DisassemblyTooltipMessage[],
+  translate: TooltipTranslator,
+) => messages.map(({key, params}) => translate(key, params))
+
+const resolveDescriptor = (
   descriptor: TooltipDescriptor,
   value: number,
-  translate: TooltipTranslator,
-) => {
+): readonly DisassemblyTooltipMessage[] => {
   switch (descriptor.kind) {
-    case "text":
-      return translate(tooltipKey("text", descriptor.key))
-    case "bit7": {
-      const label = translate(tooltipKey("labels", descriptor.labelKey))
-      if (value < 0) {
-        return translate(tooltipKey("formats", "unknown"), {label})
-      }
-      const isSet = (value & 0x80) !== 0
-      const stateKey = isSet ? descriptor.setKey : descriptor.clearKey
-      const status = translate(tooltipKey("formats", "bit7"), {
-        label,
-        state: translate(tooltipKey("states", stateKey)),
-        bit: isSet ? "1" : "0",
-      })
-      return descriptor.actionKey
-        ? translate(tooltipKey("formats", "withAction"), {
-          status,
-          action: translate(tooltipKey("text", descriptor.actionKey)),
-        })
-        : status
-    }
+    case "sequence":
+      return descriptor.parts.flatMap((part) => resolveDescriptor(part, value))
+    case "msb-choice":
+      return value < 0
+        ? []
+        : resolveDescriptor((value & 0x80) === 0 ? descriptor.zero : descriptor.one, value)
+    case "grouped-message":
+      return [groupedTooltipMessage(descriptor.group, descriptor.key, descriptor.params)]
     case "keyboard": {
-      if (value < 0) return translate(tooltipKey("formats", "keyboardUnknown"))
+      if (value < 0) return []
       const strobe = (value & 0x80) !== 0
-      return translate(tooltipKey("formats", "keyboard"), {
-        character: formatKeyboardCharacter(value),
-        state: translate(tooltipKey("states", strobe ? "set" : "clear")),
-        bit: strobe ? "1" : "0",
-      })
+      return [
+        groupedTooltipMessage("keyboard", "character", {
+          character: formatKeyboardCharacter(value),
+        }),
+        groupedTooltipMessage("keyboard", strobe ? "strobeSet" : "strobeClear"),
+      ]
     }
     case "aux-bank-selector":
-      return value < 0
-        ? translate(tooltipKey("formats", "auxiliaryBankUnknown"), {
-          addressing: descriptor.addressing,
-        })
-        : translate(tooltipKey("formats", "auxiliaryBank"), {
-          bank: `$${(value & 0xFF).toString(16).toUpperCase().padStart(2, "0")}`,
-          addressing: descriptor.addressing,
-        })
+      return value < 0 ? [] : [groupedTooltipMessage("auxMemory", "selectExpansionBank", {
+        bank: `$${(value & 0xFF).toString(16).toUpperCase().padStart(2, "0")}`,
+        addressing: descriptor.addressing,
+      })]
+    case "accelerator-control": {
+      if (value < 0) return []
+
+      const controlValue = value & 0xFF
+      const effects: DisassemblyTooltipMessage[] = []
+      switch (controlValue) {
+        case 0:
+          effects.push(groupedTooltipMessage("transWarp", "configuredMaximum"))
+          break
+        case 1:
+          effects.push(groupedTooltipMessage("transWarp", "oneMhz"))
+          break
+        case 3:
+          effects.push(groupedTooltipMessage("transWarp", "disableUntilColdBoot"))
+          break
+      }
+
+      const laserSpeedKey: TooltipGroupedMessageKey<"laser128ex"> = controlValue < 0x80
+        ? "oneMhz"
+        : controlValue < 0xC0 ? "twoPointThreeMhz" : "threePointSixMhz"
+      const laserSpeedSelection = groupedTooltipMessage("laser128ex", laserSpeedKey)
+      const laserDiskSlowdown = groupedTooltipMessage(
+        "laser128ex",
+        (controlValue & 0x20) === 0
+          ? "disableDiskSlowdown"
+          : "enableDiskSlowdown",
+      )
+
+      effects.push(laserSpeedSelection, laserDiskSlowdown)
+      return effects
+    }
   }
 }
 
 // undefined means the address is not in the semantic table and should retain
-// the generic value tooltip. An empty string means the address is known but
+// the generic value tooltip. An empty array means the address is known but
 // this operation has no meaningful state or action to display.
+export const getDisassemblyTooltipMessages = (
+  machine: MACHINE_NAME,
+  address: number,
+  opcode: string,
+  value: number,
+  operand = "",
+): readonly DisassemblyTooltipMessage[] | undefined => {
+  const row = tooltipRowsByMachineAndAddress.get(`${machine}:${address}`)
+  if (!row) return undefined
+
+  const operation = getMemoryOperation(opcode, operand)
+  if (operation === "read-modify-write" || operation === "multiple-access") {
+    const warning = warningMessage("multipleTriggers")
+    if (address < 0xC070 || address > 0xC07F) return [warning]
+
+    const descriptor = row.write ?? row.access
+    if (!descriptor) return [warning]
+    const semanticValue = operation === "read-modify-write" ? -1 : value
+    const effects = resolveDescriptor(descriptor, semanticValue)
+    if (effects.length === 0) return [warning]
+    const [paddleEffect, ...otherEffects] = effects
+    if (address === 0xC074 && operation === "read-modify-write") {
+      return [
+        paddleEffect,
+        warningMessage("unknownWrite"),
+        ...otherEffects,
+      ]
+    }
+    if (operation === "read-modify-write") {
+      if (machine !== "APPLE2P" && (address === 0xC071 || address === 0xC073)) {
+        return [
+          paddleEffect,
+          warningMessage("unknownWrite"),
+          ...otherEffects,
+        ]
+      }
+      return effects
+    }
+    return [paddleEffect, warning, ...otherEffects]
+  }
+
+  const descriptor = operation === "write"
+    ? row.write ?? row.access
+    : row.read ?? row.access
+  return descriptor ? resolveDescriptor(descriptor, value) : []
+}
+
+export const getDisassemblyTooltipLines = (
+  machine: MACHINE_NAME,
+  address: number,
+  opcode: string,
+  value: number,
+  translate: TooltipTranslator,
+  operand = "",
+): readonly string[] | undefined => {
+  const messages = getDisassemblyTooltipMessages(machine, address, opcode, value, operand)
+  return messages && renderDisassemblyTooltipMessages(messages, translate)
+}
+
 export const getDisassemblyTooltip = (
   machine: MACHINE_NAME,
   address: number,
@@ -432,17 +647,5 @@ export const getDisassemblyTooltip = (
   value: number,
   translate: TooltipTranslator,
   operand = "",
-): string | undefined => {
-  const row = tooltipRowsByMachineAndAddress.get(`${machine}:${address}`)
-  if (!row) return undefined
-
-  const operation = getMemoryOperation(opcode, operand)
-  if (operation === "read-modify-write" || operation === "multiple-access") {
-    return translate(tooltipKey("text", "triggerMultipleSoftSwitchOperations"))
-  }
-
-  const descriptor = operation === "write"
-    ? row.write ?? row.access
-    : row.read ?? row.access
-  return descriptor ? formatDescriptor(descriptor, value, translate) : ""
-}
+): string | undefined =>
+  getDisassemblyTooltipLines(machine, address, opcode, value, translate, operand)?.join("\n")

--- a/src/ui/panels/disassembly/disassemblyview_singleline.tsx
+++ b/src/ui/panels/disassembly/disassemblyview_singleline.tsx
@@ -10,11 +10,17 @@ import { faCheck, faTimes } from "@fortawesome/free-solid-svg-icons"
 import { getSymbolForAddress } from "./disassembly_utilities"
 import { willTakeBranch } from "../../../common/util_disassemble"
 import {
+  formatIndexedAddressNotation,
+  formatPreIndexedAddressNotation,
+  formatMemoryTooltip,
   getDisassemblyTooltip,
   getDisassemblyWriteValue,
+  getAddressWrapMask,
   getZeroPagePointer,
+  isolateTechnicalNotation,
+  joinDisassemblyTooltipLines,
 } from "./disassembly_tooltips"
-import type { TooltipFormatKey, TooltipTranslator } from "./disassembly_tooltips"
+import type { TooltipTranslator } from "./disassembly_tooltips"
 
 // const fWeight = (opcode: string) => {
 //   if ((["BPL", "BMI", "BVC", "BVS", "BCC", "BCS", "BNE", "BEQ", "JSR", "JMP", "RTS"]).includes(opcode)) return "bold"
@@ -53,7 +59,8 @@ const getOperandTooltip = (
   instructionAddress: number,
   translate: TooltipTranslator,
 ) => {
-  const formatKey = (key: TooltipFormatKey) => `debug.disassemblyTooltips.formats.${key}`
+  const formatEffectiveAddressTooltip = (notation: string) =>
+    formatMemoryTooltip("effectiveAddress", notation, translate)
   let addressDescription = ""
   let effectiveAddress = addr
   let value = -1
@@ -64,50 +71,46 @@ const getOperandTooltip = (
     const addrInd = getZeroPagePointer(preIndex, getShiftedMemoryValue)
     effectiveAddress = addrInd
     value = getShiftedMemoryValue(effectiveAddress)
-    addressDescription = translate(formatKey("preIndexedAddress"), {
-      base: `$${toHex(addr)}`,
-      index: `$${toHex(xreg)}`,
-      pointer: `$${toHex(preIndex)}`,
-      effectiveAddress: `$${toHex(effectiveAddress)}`,
-    })
+    addressDescription = formatEffectiveAddressTooltip(formatPreIndexedAddressNotation(
+      `$${toHex(addr)}`,
+      `$${toHex(xreg)}`,
+      `$${toHex(preIndex)}`,
+      `$${toHex(effectiveAddress)}`,
+      getAddressWrapMask(addr, xreg, 0xFF),
+    ))
   } else if (operand.includes("),Y")) {
     const yreg = handleGetState6502().YReg
     // post-indexing: find the address from memory and then add Y
     const addrInd = getZeroPagePointer(addr, getShiftedMemoryValue)
     effectiveAddress = (addrInd + yreg) & 0xFFFF
     value = getShiftedMemoryValue(effectiveAddress)
-    addressDescription = translate(formatKey("indexedAddress"), {
-      base: `$${toHex(addrInd)}`,
-      index: `$${toHex(yreg)}`,
-      effectiveAddress: `$${toHex(effectiveAddress)}`,
-    })
+    addressDescription = formatEffectiveAddressTooltip(formatIndexedAddressNotation(
+      `$${toHex(addrInd)}`, `$${toHex(yreg)}`, `$${toHex(effectiveAddress)}`,
+      getAddressWrapMask(addrInd, yreg, 0xFFFF),
+    ))
   } else if (operand.includes(",X")) {
     const xreg = handleGetState6502().XReg
     const mask = /\$[0-9A-Fa-f]{2},X/.test(operand) ? 0xFF : 0xFFFF
     effectiveAddress = (addr + xreg) & mask
     value = getShiftedMemoryValue(effectiveAddress)
-    addressDescription = translate(formatKey("indexedAddress"), {
-      base: `$${toHex(addr)}`,
-      index: `$${toHex(xreg)}`,
-      effectiveAddress: `$${toHex(effectiveAddress)}`,
-    })
+    addressDescription = formatEffectiveAddressTooltip(formatIndexedAddressNotation(
+      `$${toHex(addr)}`, `$${toHex(xreg)}`, `$${toHex(effectiveAddress)}`,
+      getAddressWrapMask(addr, xreg, mask),
+    ))
   } else if (operand.includes(",Y")) {
     const yreg = handleGetState6502().YReg
     const mask = /\$[0-9A-Fa-f]{2},Y/.test(operand) ? 0xFF : 0xFFFF
     effectiveAddress = (addr + yreg) & mask
     value = getShiftedMemoryValue(effectiveAddress)
-    addressDescription = translate(formatKey("indexedAddress"), {
-      base: `$${toHex(addr)}`,
-      index: `$${toHex(yreg)}`,
-      effectiveAddress: `$${toHex(effectiveAddress)}`,
-    })
+    addressDescription = formatEffectiveAddressTooltip(formatIndexedAddressNotation(
+      `$${toHex(addr)}`, `$${toHex(yreg)}`, `$${toHex(effectiveAddress)}`,
+      getAddressWrapMask(addr, yreg, mask),
+    ))
   } else if (operand.includes(")")) {
     const addrInd = getZeroPagePointer(addr, getShiftedMemoryValue)
     effectiveAddress = addrInd
     value = getShiftedMemoryValue(effectiveAddress)
-    addressDescription = translate(formatKey("indirectAddress"), {
-      effectiveAddress: `$${toHex(effectiveAddress)}`,
-    })
+    addressDescription = formatEffectiveAddressTooltip(`$${toHex(effectiveAddress)}`)
   } else if (operand.includes("$")) {
     value = getShiftedMemoryValue(effectiveAddress)
   }
@@ -122,13 +125,13 @@ const getOperandTooltip = (
     operand,
   )
   if (semanticTooltip !== undefined) {
-    return [addressDescription, semanticTooltip].filter(Boolean).join("  ")
+    return joinDisassemblyTooltipLines(addressDescription, semanticTooltip)
   }
 
   const valueDescription = value >= 0
-    ? translate(formatKey("value"), {value: `$${toHex(value)}`})
+    ? formatMemoryTooltip("value", `$${toHex(value)}`, translate)
     : ""
-  return [addressDescription, valueDescription].filter(Boolean).join("  ")
+  return joinDisassemblyTooltipLines(addressDescription, valueDescription)
 }
 
 
@@ -155,7 +158,7 @@ const getJumpLink = (opcode: string, operand: string, onJumpClick: (addr: number
       takebranch = willTakeBranch(opcode, s6502.PStatus) ? yes : no
     }
     return <span>{ops[0]}<span className="disassembly-link"
-        title={`$${toHex(addr)}`}
+        title={isolateTechnicalNotation(`$${toHex(addr)}`)}
         onClick={() => {onJumpClick(addr)}}>{ops[1]}</span>
       <span>{ops[2]}</span>
       {takebranch}
@@ -187,7 +190,9 @@ const getOperand = (
       if (cvalue <= 31) cvalue += 64
       char = ` = "${caret}${String.fromCharCode(cvalue)}"`
     }
-    title += `${value.toString()} = ${(value | 256).toString(2).slice(1)}${char}`
+    title += isolateTechnicalNotation(
+      `${value.toString()} = ${(value | 256).toString(2).slice(1)}${char}`,
+    )
     className = "disassembly-immediate"
   } else {
     const ops = operand.split(/(\$[0-9A-Fa-f]{2,4})/)

--- a/tools/render-disassembly-tooltip-review.mjs
+++ b/tools/render-disassembly-tooltip-review.mjs
@@ -8,6 +8,37 @@ const SOURCE_URL = new URL("../src/ui/panels/disassembly/disassembly_tooltips.ts
 const ENGLISH_CATALOG_URL = new URL("../src/i18n/languages/en.ts", import.meta.url)
 const REVIEW_OUTPUT_URL = new URL("../docs/reviews/", import.meta.url)
 const MACHINE_ORDER = ["APPLE2P", "APPLE2EU", "APPLE2EE"]
+const INSTRUCTION_SENSITIVE_SCENARIOS = [
+  {instruction: "INC $C030", address: 0xC030, opcode: "INC", operand: "$C030"},
+  {
+    instruction: "STA $C070,X (X = $03)",
+    address: 0xC073,
+    opcode: "STA",
+    operand: "$C070,X",
+    value: 0x03,
+  },
+  {
+    instruction: "INC $C073",
+    address: 0xC073,
+    opcode: "INC",
+    operand: "$C073",
+    valueLabel: "UNKNOWN",
+  },
+  {
+    instruction: "STA $C070,X (X = $04)",
+    address: 0xC074,
+    opcode: "STA",
+    operand: "$C070,X",
+    value: 0x01,
+  },
+  {
+    instruction: "INC $C074",
+    address: 0xC074,
+    opcode: "INC",
+    operand: "$C074",
+    valueLabel: "UNKNOWN",
+  },
+]
 
 const machineType = (machines) => {
   const normalized = [...machines].sort((left, right) =>
@@ -53,41 +84,120 @@ export const createCatalogTranslator = (catalog) =>
     return result
   }
 
-const loadEnglishTranslator = async () => {
-  const { en } = await loadTypeScriptModule(ENGLISH_CATALOG_URL)
-  return createCatalogTranslator(en)
+const loadEnglishCatalog = async () =>
+  (await loadTypeScriptModule(ENGLISH_CATALOG_URL)).en
+
+const loadEnglishTranslator = async () =>
+  createCatalogTranslator(await loadEnglishCatalog())
+
+const markdownCell = (value) => String(value)
+  .replaceAll("|", "\\|")
+  .replaceAll("\n", "<br>")
+
+const templateFields = (message) =>
+  [...message.matchAll(/{{([^{}]+)}}/g)].map((match) => match[1]).join(", ") || "—"
+
+export const renderDisassemblyTranslationKeyReview = async () => {
+  const catalog = (await loadEnglishCatalog()).disassembly
+  const direct = []
+  const groups = []
+
+  for (const [key, value] of Object.entries(catalog)) {
+    if (typeof value === "string") {
+      direct.push([key, value])
+    } else {
+      groups.push([key, Object.entries(value)])
+    }
+  }
+
+  const groupedCount = groups.reduce((sum, [, entries]) => sum + entries.length, 0)
+  const flattened = [
+    ...direct.map(([key, message]) => ({key, message})),
+    ...groups.flatMap(([group, entries]) =>
+      entries.map(([key, message]) => ({key: `${group}.${key}`, message}))),
+  ]
+  const longest = flattened
+    .filter(({key}) => key.length >= 24)
+    .sort((left, right) =>
+      right.key.length - left.key.length || left.key.localeCompare(right.key))
+
+  const lines = [
+    "# Disassembly translation-key structure review",
+    "",
+    `This catalog contains ${flattened.length} strings: ${direct.length} direct strings and ${groupedCount} strings in ${groups.length} named groups.`,
+    "",
+    "Keys are grouped by hardware or UI concern. Every entry is a complete rendered line; interpolation supplies runtime data rather than separately translated fragments.",
+    "",
+    "## Longest relative key paths",
+    "",
+    "| Length | Key | English |",
+    "|---:|---|---|",
+  ]
+
+  for (const {key, message} of longest) {
+    lines.push(`| ${key.length} | \`${markdownCell(key)}\` | ${markdownCell(message)} |`)
+  }
+
+  if (direct.length > 0) {
+    lines.push(
+      "",
+      "## Direct strings",
+      "",
+      "| Key | English | Fields |",
+      "|---|---|---|",
+    )
+    for (const [key, message] of direct) {
+      lines.push(`| \`${markdownCell(key)}\` | ${markdownCell(message)} | ${markdownCell(templateFields(message))} |`)
+    }
+  }
+
+  for (const [group, entries] of groups) {
+    lines.push("", `## ${group}`, "", "| Key | English | Fields |", "|---|---|---|")
+    for (const [key, message] of entries) {
+      lines.push(`| \`${markdownCell(group)}.${markdownCell(key)}\` | ${markdownCell(message)} | ${markdownCell(templateFields(message))} |`)
+    }
+  }
+
+  return `${lines.join("\n")}\n`
 }
 
 const examplesFor = (descriptor) => {
   switch (descriptor.kind) {
+    case "sequence": {
+      const examples = descriptor.parts.flatMap(examplesFor)
+      const valuedExamples = examples.filter(({value}) => value !== undefined)
+      return valuedExamples.length > 0
+        ? [...new Map(valuedExamples.map((example) => [example.value, example])).values()]
+        : [{}]
+    }
     case "keyboard":
       return [{value: 0x5D}, {value: 0xDD}]
-    case "bit7":
+    case "msb-choice":
       return [{value: 0x00}, {value: 0x80}]
     case "aux-bank-selector":
       return [{value: 0x03}]
-    case "text":
+    case "accelerator-control":
+      return [
+        {value: 0x00},
+        {value: 0x01},
+        {value: 0x03},
+        {value: 0x40},
+        {value: 0xA0},
+        {value: 0xC0},
+      ]
+    case "grouped-message":
       return [{}]
     default:
       throw new Error(`Unsupported tooltip descriptor: ${descriptor.kind}`)
   }
 }
 
-const markdownTooltip = (tooltip, descriptor) => {
-  switch (descriptor.kind) {
-    case "keyboard":
-      return tooltip.replace(
-        /^Keyboard = "(.*)"; Strobe is (CLEAR|SET) \(bit 7 = ([01])\)$/,
-        "Keyboard = \"`$1`\"; Strobe is `$2` (bit 7 = `$3`)",
-      )
-    case "bit7":
-      return tooltip.replace(
-        / = ([^;(]+) \(bit 7 = ([01])\)/,
-        " = `$1` (bit 7 = `$2`)",
-      )
-    default:
-      return tooltip
-  }
+const markdownTooltip = (tooltip) => {
+  const withRuntimeValues = tooltip
+    .replace(/^Keyboard: "(.*)"$/m, "Keyboard: \"`$1`\"")
+    .replace(/: ([^\n(]+) \(MSB = ([01])\)/g, ": `$1` (MSB = `$2`)")
+    .replace(/\(MSB = ([01])\)/g, "(MSB = `$1`)")
+  return withRuntimeValues.replace(/\n/g, "<br>")
 }
 
 export const renderDisassemblyTooltipReview = async ({
@@ -101,14 +211,20 @@ export const renderDisassemblyTooltipReview = async ({
   const scenarios = new Map()
 
   for (const row of rows) {
-    for (const [access, descriptor] of [
-      ["Read/write", row.access],
-      ["Read", row.read],
-      ["Write", row.write],
-    ]) {
-      if (!descriptor) continue
+    const descriptors = row.access && (row.read || row.write)
+      ? [
+        ["Read", row.read ?? row.access],
+        ["Write", row.write ?? row.access],
+      ]
+      : row.access
+        ? [["Read/write", row.access]]
+        : [
+          ["Read", row.read],
+          ["Write", row.write],
+        ]
+    for (const [access, descriptor] of descriptors) {
       const opcode = access === "Write" ? "STA" : "LDA"
-      for (const example of examplesFor(descriptor)) {
+      for (const example of descriptor ? examplesFor(descriptor) : [{}]) {
         for (const machine of row.machines.filter((name) => machines.includes(name))) {
           const tooltip = getDisassemblyTooltip(
             machine,
@@ -117,12 +233,13 @@ export const renderDisassemblyTooltipReview = async ({
             example.value ?? 0,
             translate,
           )
-          if (!tooltip) continue
+          if (tooltip === undefined) continue
+          const renderedTooltip = tooltip || "No semantic tooltip"
           const scenario = {
             access,
             address: row.address,
-            markdown: markdownTooltip(tooltip, descriptor),
-            tooltip,
+            markdown: tooltip ? markdownTooltip(tooltip) : "_No semantic tooltip_",
+            tooltip: renderedTooltip,
             value: example.value === undefined ? "" : hex(example.value),
           }
           const key = JSON.stringify(scenario)
@@ -138,7 +255,7 @@ export const renderDisassemblyTooltipReview = async ({
   const lines = [
     `# ${title}`,
     "",
-    "Each row is a concrete rendered tooltip. Adjacent addresses with the same behavior share one range. Blue code spans mark only runtime-dependent text; they are not part of the actual tooltip.",
+    "Each row records the semantic-tooltip outcome. Adjacent addresses with the same behavior share one range. _No semantic tooltip_ means that the address is known but the operation intentionally displays no semantic or generic value tooltip. Blue code spans mark only runtime-dependent text; they are not part of the actual tooltip.",
     "The Value column uses representative runtime values only to make conditional tooltip text concrete; it does not imply a particular source register, preceding instruction, or machine state.",
     "",
     includeType
@@ -195,13 +312,59 @@ export const renderDisassemblyTooltipReview = async ({
       ? `| ${address} | ${scenario.machine} | ${scenario.access} | ${scenario.value} | ${scenario.markdown} |`
       : `| ${address} | ${scenario.access} | ${scenario.value} | ${scenario.markdown} |`)
   }
+
+  lines.push(
+    "",
+    "## Instruction-sensitive cases",
+    "",
+    "These representative instructions exercise tooltips whose meaning or warning depends on how the instruction accesses the soft switch. Indexed and indirect examples assume that the displayed instruction is at the current PC; paused state does not reliably resolve those operands on other rows (issue #303).",
+    "",
+    includeType
+      ? "| Instruction | Type | Write value | Tooltip |"
+      : "| Instruction | Write value | Tooltip |",
+    includeType
+      ? "|---|---|---|---|"
+      : "|---|---|---|",
+  )
+  const instructionScenarios = new Map()
+  for (const scenario of INSTRUCTION_SENSITIVE_SCENARIOS) {
+    for (const machine of machines) {
+      const tooltip = getDisassemblyTooltip(
+        machine,
+        scenario.address,
+        scenario.opcode,
+        scenario.value ?? 0,
+        translate,
+        scenario.operand,
+      )
+      if (!tooltip) continue
+      const key = JSON.stringify({
+        instruction: scenario.instruction,
+        tooltip,
+        value: scenario.value,
+        valueLabel: scenario.valueLabel,
+      })
+      if (!instructionScenarios.has(key)) {
+        instructionScenarios.set(key, {...scenario, tooltip, machines: new Set()})
+      }
+      instructionScenarios.get(key).machines.add(machine)
+    }
+  }
+  for (const scenario of instructionScenarios.values()) {
+    const instruction = `\`${scenario.instruction}\``
+    const value = scenario.valueLabel ?? (scenario.value === undefined ? "—" : hex(scenario.value))
+    const tooltip = markdownTooltip(scenario.tooltip)
+    lines.push(includeType
+      ? `| ${instruction} | ${machineType(scenario.machines)} | ${value} | ${tooltip} |`
+      : `| ${instruction} | ${value} | ${tooltip} |`)
+  }
   return `${lines.join("\n")}\n`
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   if (process.argv.includes("--write")) {
     await fs.mkdir(REVIEW_OUTPUT_URL, {recursive: true})
-    const [apple2pReview, apple2eReview] = await Promise.all([
+    const [apple2pReview, apple2eReview, keyReview] = await Promise.all([
       renderDisassemblyTooltipReview({
         machines: ["APPLE2P"],
         title: "Apple II+ disassembly tooltip review",
@@ -212,6 +375,7 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
         title: "Apple IIe disassembly tooltip review",
         includeType: false,
       }),
+      renderDisassemblyTranslationKeyReview(),
     ])
     await Promise.all([
       fs.writeFile(
@@ -222,7 +386,13 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
         new URL("disassembly-tooltips-apple2e.md", REVIEW_OUTPUT_URL),
         apple2eReview,
       ),
+      fs.writeFile(
+        new URL("disassembly-translation-keys.md", REVIEW_OUTPUT_URL),
+        keyReview,
+      ),
     ])
+  } else if (process.argv.includes("--keys")) {
+    process.stdout.write(await renderDisassemblyTranslationKeyReview())
   } else {
     process.stdout.write(await renderDisassemblyTooltipReview())
   }

--- a/tools/render-disassembly-tooltip-review.test.mjs
+++ b/tools/render-disassembly-tooltip-review.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict"
 import fs from "node:fs/promises"
 import {
   createCatalogTranslator,
+  renderDisassemblyTranslationKeyReview,
   renderDisassemblyTooltipReview,
 } from "./render-disassembly-tooltip-review.mjs"
 
@@ -25,13 +26,27 @@ test("renders concrete tooltip examples from the resolver", async () => {
 
   assert.match(review, /^# Disassembly tooltip review$/m)
   assert.match(review, /The Value column uses representative runtime values only to make conditional tooltip text concrete/)
-  assert.match(review, /\| \$C000–\$C00F \| II\* \| Read \| \$5D \| Keyboard = "`\]`"; Strobe is `CLEAR` \(bit 7 = `0`\) \|/)
-  assert.match(review, /\| \$C000 \| IIe \| Write \| {2}\| Disable PAGE2 display-memory banking \|/)
-  assert.match(review, /\| \$C071 \| IIe \| Write \| \$03 \| Select auxiliary bank \$03 using Neptune addressing; start paddle timers \|/)
-  assert.match(review, /\| \$C073 \| IIe \| Write \| \$03 \| Select auxiliary bank \$03 using RamWorks addressing; start paddle timers \|/)
-  assert.match(review, /Write ignored on Apple II\+/)
+  assert.match(review, /\| \$C000–\$C00F \| II\* \| Read \| \$5D \| Keyboard: "`\]`"<br>Keyboard strobe: `CLEAR` \(MSB = `0`\) \|/)
+  assert.match(review, /\| \$C000 \| IIe \| Write \| {2}\| Make PAGE2 select display page 1 or 2 \|/)
+  assert.match(review, /\| \$C00D \| IIe \| Write \| {2}\| Set display width to 80 columns \|/)
+  assert.match(review, /\| \$C018 \| IIe \| Read \| \$80 \| PAGE2 selects main or auxiliary display memory \(MSB = `1`\) \|/)
+  assert.match(review, /\| \$C05E \| IIe \| Read\/write \| {2}\| Disable annunciator 3<br>Enable DHIRES \|/)
+  assert.match(review, /\| \$C071 \| IIe \| Write \| \$03 \| Start paddle timers<br>Select auxiliary expansion bank \$03 using Neptune addressing \|/)
+  assert.match(review, /\| \$C073 \| IIe \| Write \| \$03 \| Start paddle timers<br>Select auxiliary expansion bank \$03 using RamWorks addressing \|/)
+  assert.match(review, /\| \$C074 \| II\* \| Write \| \$A0 \| Start paddle timers<br>Laser 128EX: Select 2\.3 MHz maximum CPU speed<br>Laser 128EX: Enable automatic 1 MHz slowdown for port 7 disk access \(write-once bit 5\) \|/)
+  assert.match(review, /\| \$C083 \| II\* \| Read \| {2}\| Language Card: Select bank 2<br>Language Card: Use RAM for reads<br>Language Card: Arm or enable writes \|/)
+  assert.match(review, /\| \$C075–\$C07F \| II\* \| Read\/write \| {2}\| Start paddle timers \|/)
+  assert.match(review, /INFO: This write has no effect on Apple II\+/)
   assert.match(review, /\| \$C010–\$C01F \| II\+ \| Read\/write \| {2}\| Clear keyboard strobe \|/)
-  assert.doesNotMatch(review, /No tooltip|N\/A/)
+  assert.match(review, /\| \$C060–\$C06F \| II\* \| Write \| {2}\| _No semantic tooltip_ \|/)
+  assert.match(review, /^## Instruction-sensitive cases$/m)
+  assert.match(review, /^\| Instruction \| Type \| Write value \| Tooltip \|$/m)
+  assert.match(review, /\| `INC \$C030` \| II\* \| — \| WARNING: This instruction triggers the soft switch multiple times \|/)
+  assert.match(review, /\| `STA \$C070,X \(X = \$03\)` \| IIe \| \$03 \| Start paddle timers<br>WARNING: This instruction triggers the soft switch multiple times<br>Select auxiliary expansion bank \$03 using RamWorks addressing \|/)
+  assert.match(review, /\| `INC \$C073` \| IIe \| UNKNOWN \| Start paddle timers<br>WARNING: This instruction writes an unknown value \|/)
+  assert.match(review, /\| `STA \$C070,X \(X = \$04\)` \| II\* \| \$01 \| Start paddle timers<br>WARNING: This instruction triggers the soft switch multiple times<br>TransWarp: Select 1 MHz<br>Laser 128EX: Select 1 MHz maximum CPU speed<br>Laser 128EX: Disable automatic 1 MHz slowdown for port 7 disk access \(write-once bit 5\) \|/)
+  assert.match(review, /\| `INC \$C074` \| II\* \| UNKNOWN \| Start paddle timers<br>WARNING: This instruction writes an unknown value \|/)
+  assert.doesNotMatch(review, /N\/A/)
 })
 
 test("renders a machine-specific review without a Type column", async () => {
@@ -44,8 +59,31 @@ test("renders a machine-specific review without a Type column", async () => {
   assert.match(review, /^# Apple II\+ disassembly tooltip review$/m)
   assert.match(review, /^\| Range \| Access \| Value \| Tooltip \|$/m)
   assert.doesNotMatch(review, /\| Type \|/)
+  assert.match(review, /^\| Instruction \| Write value \| Tooltip \|$/m)
   assert.match(review, /\| \$C010–\$C01F \| Read\/write \| {2}\| Clear keyboard strobe \|/)
   assert.doesNotMatch(review, /Language Card Bank/)
+})
+
+test("renders the disassembly translation-key hierarchy", async () => {
+  const review = await renderDisassemblyTranslationKeyReview()
+
+  assert.match(review, /^# Disassembly translation-key structure review$/m)
+  assert.match(review, /^## Longest relative key paths$/m)
+  assert.match(review, /98 strings: 0 direct strings and 98 strings in 14 named groups/)
+  assert.doesNotMatch(review, /^## Direct strings$/m)
+  assert.doesNotMatch(review, /^## diagnostic$/m)
+  assert.match(review, /\| `notice\.emulatorIdentifier` \| INFO: Apple2TS emulator identifier: \$CD \| — \|/)
+  assert.match(review, /\| `notice\.noWriteEffect` \| INFO: This write has no effect on {{machine}} \| machine \|/)
+  assert.match(review, /\| `notice\.multipleTriggers` \| WARNING: This instruction triggers the soft switch multiple times \| — \|/)
+  assert.match(review, /\| `notice\.unknownWrite` \| WARNING: This instruction writes an unknown value \| — \|/)
+  assert.match(review, /\| `displayMemory\.80storeStatusOn` \| PAGE2 selects main or auxiliary display memory \(MSB = 1\) \| — \|/)
+  assert.match(review, /\| `display\.textModeStatusOn` \| Text mode: ON \(MSB = 1\) \| — \|/)
+  assert.match(review, /\| `gameIO\.buttonPressed` \| Pushbutton {{number}}: PRESSED \(MSB = 1\) \| number \|/)
+  assert.doesNotMatch(review, /Label`|## states$|## devices$/m)
+  assert.match(review, /\| `display\.selectGraphicsMode` \| Select graphics mode \| — \|/)
+  assert.match(review, /\| `memory\.effectiveAddress` \| Effective address: {{notation}} \| notation \|/)
+  assert.match(review, /\| `annunciator\.enable` \| Enable annunciator {{number}} \| number \|/)
+  assert.match(review, /\| `auxMemory\.altzpStatusAuxiliary` \| Zero page, stack, and bank-switched RAM: AUXILIARY \(MSB = 1\) \| — \|/)
 })
 
 test("keeps checked-in machine reviews synchronized with the resolver", async () => {
@@ -71,4 +109,11 @@ test("keeps checked-in machine reviews synchronized with the resolver", async ()
     const checkedIn = await fs.readFile(new URL(review.path, import.meta.url), "utf8")
     assert.equal(checkedIn, expected)
   }
+
+  const expectedKeys = await renderDisassemblyTranslationKeyReview()
+  const checkedInKeys = await fs.readFile(
+    new URL("../docs/reviews/disassembly-translation-keys.md", import.meta.url),
+    "utf8",
+  )
+  assert.equal(checkedInKeys, expectedKeys)
 })


### PR DESCRIPTION
## Summary

- Explain soft-switch accesses using the selected machine, instruction type, and read/write context.
- Use the active instruction’s source register for store intent without presenting speculative register values on other disassembly rows.
- Present independent hardware effects as separate translated lines and use English fallback for untranslated messages.
- Add a tooltip style guide and deterministic generated review tables with synchronization tests.

Generic address and memory-value tooltips remain available outside the semantic soft-switch table. Before this change, a store operand’s generic tooltip displayed the byte already present at the destination; it did not claim that byte was the value being stored.

This extends the tooltip support introduced for #82.

## Testing

- `npm test -- --runInBand` — 445 tests passed
- `npm run test-disassembly-tooltip-review` — 5 tests passed
- `npm run lint`
- `npm run build --ignore-scripts`