### PR TITLE
refactor(i18n): require literal translation keys

### DIFF
--- a/src/ui/controls/speeddropdown.tsx
+++ b/src/ui/controls/speeddropdown.tsx
@@ -12,10 +12,9 @@ import { setPreferenceSpeedMode } from "../localstorage"
 import { snailIcon } from "../img/icon_snail"
 import { turtleIcon } from "../img/icon_turtle"
 
-const speedNames = ["0.1 MHz (Snail)", "0.5 MHz (Slow)", "1 MHz", "2 MHz",
-  "3 MHz", "4 MHz (Fast)", "Ludicrous"]
+const MinimumSpeedMode = -2
 
-export const MaximumSpeedMode = speedNames.length - 2 - 1
+export const MaximumSpeedMode = 4
 
 import { useTranslation } from "../../i18n/useTranslation"
 
@@ -32,16 +31,23 @@ export const SpeedDropdown = (props: { updateDisplay: UpdateDisplay }) => {
     <FontAwesomeIcon key="3" icon={faTruckFast} style={{ fontSize: `${iconSize}px` }} />,
     <FontAwesomeIcon key="4" icon={faRocket} style={{ fontSize: `${iconSize}px` }} />
   ]
-  const icon = icons[speedMode + 2] // Adjust for the first two modes (snail and turtle)
+  const speedIndex = speedMode - MinimumSpeedMode
+  const icon = icons[speedIndex]
+  const speedLabels = [
+    t("speed.snail"),
+    t("speed.slow"),
+    t("speed.normal"),
+    t("speed.two"),
+    t("speed.three"),
+    t("speed.fast"),
+    t("speed.warp"),
+  ]
 
   return (
     <DropdownButton
-      currentIndex={speedMode + 2}
-      itemNames={speedNames.map((name, index) => {
-        const speedKeys = ["snail", "slow", "normal", "two", "three", "fast", "warp"]
-        return t(`speed.${speedKeys[index]}`)
-      })}
-      closeCallback={(index: number) => { setPreferenceSpeedMode(index - 2); props.updateDisplay() }}
+      currentIndex={speedIndex}
+      itemNames={speedLabels}
+      closeCallback={(index: number) => { setPreferenceSpeedMode(index + MinimumSpeedMode); props.updateDisplay() }}
       icon={icon}
       icons={icons}
       tooltip={t("config.speed")}

--- a/src/ui/devices/displayconfig.tsx
+++ b/src/ui/devices/displayconfig.tsx
@@ -17,6 +17,14 @@ export const DisplayConfig = (props: { updateDisplay: UpdateDisplay }) => {
   const showScanlines = getShowScanlines()
   const ghosting = getGhosting()
   const crtDistortion = getCrtDistortion()
+  const colorNames = [
+    t("colors.color"),
+    t("colors.nofringe"),
+    t("colors.green"),
+    t("colors.amber"),
+    t("colors.white"),
+    t("colors.inverse"),
+  ]
 
   const [popupLocation, setPopupLocation] = useState<[number, number]>()
   const handleClick = (event: React.MouseEvent) => {
@@ -46,7 +54,7 @@ export const DisplayConfig = (props: { updateDisplay: UpdateDisplay }) => {
         menuItems={[[
           ...Object.values(COLOR_MODE).filter(value => typeof value === "number").map((i) => (
             {
-              label: t(`colors.${(["color", "nofringe", "green", "amber", "white", "inverse"])[i]}`),
+              label: colorNames[i],
               isSelected: () => { return i == colorMode },
               onClick: () => {
                 setPreferenceColorMode(i)

--- a/tools/i18n/catalog-config.test.mjs
+++ b/tools/i18n/catalog-config.test.mjs
@@ -34,11 +34,20 @@ const translationKeyCalls = sourceFile => {
       const callee = node.expression
       const isTranslationCall = ts.isIdentifier(callee)
         ? callee.text === "t"
-        : ts.isPropertyAccessExpression(callee) && callee.name.text === "t"
+        : ts.isPropertyAccessExpression(callee)
+          && ts.isIdentifier(callee.expression)
+          && callee.expression.text === "i18n"
+          && callee.name.text === "t"
       const argument = node.arguments[0]
-      if (isTranslationCall && argument
-          && (ts.isStringLiteral(argument) || ts.isNoSubstitutionTemplateLiteral(argument))) {
-        calls.push(argument.text)
+      if (isTranslationCall) {
+        const {line} = sourceFile.getLineAndCharacterOfPosition(node.getStart())
+        calls.push({
+          key: argument
+            && (ts.isStringLiteral(argument) || ts.isNoSubstitutionTemplateLiteral(argument))
+            ? argument.text
+            : undefined,
+          line: line + 1,
+        })
       }
     }
     ts.forEachChild(node, visit)
@@ -82,8 +91,13 @@ describe("catalog configuration", () => {
         true,
         file.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
       )
-      for (const key of translationKeyCalls(sourceFile)) {
-        if (!englishKeys.has(key)) missing.push(`${relative(".", file)}: ${key}`)
+      for (const {key, line} of translationKeyCalls(sourceFile)) {
+        const location = `${relative(".", file)}:${line}`
+        if (key === undefined) {
+          missing.push(`${location}: translation key must be a string literal`)
+        } else if (!englishKeys.has(key)) {
+          missing.push(`${location}: missing ${key}`)
+        }
       }
     }
 


### PR DESCRIPTION
Apple2TS’s catalog check can verify only translation keys that are visible in source. The speed and display controls constructed some keys dynamically, allowing missing catalog entries to escape that check.

- Call `t()` with literal speed and display-color keys.
- Express the speed-mode bounds and index conversion directly while preserving existing numeric values and ordering.
- Reject nonliteral `t()` and `i18n.t()` calls during catalog checks and report their source lines.

Tests: `npm test -- --runInBand` — 46 PO-tool tests and 509 Jest tests passed.