### PR TITLE
chore(i18n): remove unused tour translations

### DIFF
--- a/src/i18n/catalogs/de.po
+++ b/src/i18n/catalogs/de.po
@@ -1289,16 +1289,6 @@ msgid "TypeScript Apple IIe Emulator"
 msgstr "Apple IIe Emulator in TypeScript"
 
 #, fuzzy
-msgctxt "help.startTour"
-msgid "Click on the <b>Start Tour</b> globe"
-msgstr "Klicken Sie auf den Globus <b>Tour Starten</b>"
-
-#, fuzzy
-msgctxt "help.startTourAction"
-msgid "button to begin a guided tour of the emulator."
-msgstr "Taste, um eine geführte Tour des Emulators zu beginnen."
-
-#, fuzzy
 msgctxt "help.keyboardShortcuts"
 msgid "Keyboard Shortcuts"
 msgstr "Tastaturkürzel"

--- a/src/i18n/catalogs/es.po
+++ b/src/i18n/catalogs/es.po
@@ -1278,16 +1278,6 @@ msgid "TypeScript Apple IIe Emulator"
 msgstr "Emulador de Apple IIe en TypeScript"
 
 #, fuzzy
-msgctxt "help.startTour"
-msgid "Click on the <b>Start Tour</b> globe"
-msgstr "Haga clic en el globo <b>Iniciar Recorrido</b>"
-
-#, fuzzy
-msgctxt "help.startTourAction"
-msgid "button to begin a guided tour of the emulator."
-msgstr "para comenzar una visita guiada por el emulador."
-
-#, fuzzy
 msgctxt "help.keyboardShortcuts"
 msgid "Keyboard Shortcuts"
 msgstr "Atajos de Teclado"

--- a/src/i18n/catalogs/fr.po
+++ b/src/i18n/catalogs/fr.po
@@ -1286,16 +1286,6 @@ msgid "TypeScript Apple IIe Emulator"
 msgstr "Émulateur Apple IIe en TypeScript"
 
 #, fuzzy
-msgctxt "help.startTour"
-msgid "Click on the <b>Start Tour</b> globe"
-msgstr "Cliquez sur le globe <b>Démarrer la visite</b>"
-
-#, fuzzy
-msgctxt "help.startTourAction"
-msgid "button to begin a guided tour of the emulator."
-msgstr "pour commencer une visite guidata de l'émulateur."
-
-#, fuzzy
 msgctxt "help.keyboardShortcuts"
 msgid "Keyboard Shortcuts"
 msgstr "Raccourcis Clavier"

--- a/src/i18n/catalogs/it.po
+++ b/src/i18n/catalogs/it.po
@@ -1278,16 +1278,6 @@ msgid "TypeScript Apple IIe Emulator"
 msgstr "Emulatore Apple IIe in TypeScript"
 
 #, fuzzy
-msgctxt "help.startTour"
-msgid "Click on the <b>Start Tour</b> globe"
-msgstr "Fai clic sul globo <b>Inizia il Tour</b>"
-
-#, fuzzy
-msgctxt "help.startTourAction"
-msgid "button to begin a guided tour of the emulator."
-msgstr "per iniziare una visita guidata dell'emulatore."
-
-#, fuzzy
 msgctxt "help.keyboardShortcuts"
 msgid "Keyboard Shortcuts"
 msgstr "Scorciatoie Tastiera"

--- a/src/i18n/catalogs/ja.po
+++ b/src/i18n/catalogs/ja.po
@@ -1239,16 +1239,6 @@ msgid "TypeScript Apple IIe Emulator"
 msgstr "TypeScript Apple IIe エミュレータ"
 
 #, fuzzy
-msgctxt "help.startTour"
-msgid "Click on the <b>Start Tour</b> globe"
-msgstr "ツアー開始をクリック"
-
-#, fuzzy
-msgctxt "help.startTourAction"
-msgid "button to begin a guided tour of the emulator."
-msgstr "ボタンでエミュレータのガイド付きツアーを開始します。"
-
-#, fuzzy
 msgctxt "help.keyboardShortcuts"
 msgid "Keyboard Shortcuts"
 msgstr "キーボードショートカット"

--- a/src/i18n/catalogs/ko.po
+++ b/src/i18n/catalogs/ko.po
@@ -1244,16 +1244,6 @@ msgid "TypeScript Apple IIe Emulator"
 msgstr "TypeScript Apple IIe 에뮬레이터"
 
 #, fuzzy
-msgctxt "help.startTour"
-msgid "Click on the <b>Start Tour</b> globe"
-msgstr "투어 시작 클릭"
-
-#, fuzzy
-msgctxt "help.startTourAction"
-msgid "button to begin a guided tour of the emulator."
-msgstr "버튼을 눌러 에뮬레이터의 가이드 투어를 시작하세요."
-
-#, fuzzy
 msgctxt "help.keyboardShortcuts"
 msgid "Keyboard Shortcuts"
 msgstr "키보드 단축키"

--- a/src/i18n/catalogs/messages.pot
+++ b/src/i18n/catalogs/messages.pot
@@ -1068,14 +1068,6 @@ msgctxt "help.subtitle"
 msgid "TypeScript Apple IIe Emulator"
 msgstr ""
 
-msgctxt "help.startTour"
-msgid "Click on the <b>Start Tour</b> globe"
-msgstr ""
-
-msgctxt "help.startTourAction"
-msgid "button to begin a guided tour of the emulator."
-msgstr ""
-
 msgctxt "help.keyboardShortcuts"
 msgid "Keyboard Shortcuts"
 msgstr ""

--- a/src/i18n/catalogs/nl.po
+++ b/src/i18n/catalogs/nl.po
@@ -1277,16 +1277,6 @@ msgid "TypeScript Apple IIe Emulator"
 msgstr "TypeScript Apple IIe Emulator"
 
 #, fuzzy
-msgctxt "help.startTour"
-msgid "Click on the <b>Start Tour</b> globe"
-msgstr "Klik op de globe <b>Tour Starten</b>"
-
-#, fuzzy
-msgctxt "help.startTourAction"
-msgid "button to begin a guided tour of the emulator."
-msgstr "knop om een rondleiding door de emulator te beginnen."
-
-#, fuzzy
 msgctxt "help.keyboardShortcuts"
 msgid "Keyboard Shortcuts"
 msgstr "Sneltoetsen"

--- a/src/i18n/catalogs/pt-BR.po
+++ b/src/i18n/catalogs/pt-BR.po
@@ -1273,16 +1273,6 @@ msgid "TypeScript Apple IIe Emulator"
 msgstr "Emulador de Apple IIe em TypeScript"
 
 #, fuzzy
-msgctxt "help.startTour"
-msgid "Click on the <b>Start Tour</b> globe"
-msgstr "Clique no globo <b>Iniciar Tour</b>"
-
-#, fuzzy
-msgctxt "help.startTourAction"
-msgid "button to begin a guided tour of the emulator."
-msgstr "para iniciar um tour guiado pelo emulador."
-
-#, fuzzy
 msgctxt "help.keyboardShortcuts"
 msgid "Keyboard Shortcuts"
 msgstr "Atalhos de Teclado"

--- a/src/i18n/catalogs/ru.po
+++ b/src/i18n/catalogs/ru.po
@@ -1279,16 +1279,6 @@ msgid "TypeScript Apple IIe Emulator"
 msgstr "Эмулятор Apple IIe на TypeScript"
 
 #, fuzzy
-msgctxt "help.startTour"
-msgid "Click on the <b>Start Tour</b> globe"
-msgstr "Нажмите на глобус <b>Начать экскурсию</b>"
-
-#, fuzzy
-msgctxt "help.startTourAction"
-msgid "button to begin a guided tour of the emulator."
-msgstr "чтобы начать ознакомительную экскурсию по эмулятору."
-
-#, fuzzy
 msgctxt "help.keyboardShortcuts"
 msgid "Keyboard Shortcuts"
 msgstr "Горячие клавиши"

--- a/src/i18n/catalogs/sv.po
+++ b/src/i18n/catalogs/sv.po
@@ -1274,16 +1274,6 @@ msgid "TypeScript Apple IIe Emulator"
 msgstr "TypeScript Apple IIe Emulator"
 
 #, fuzzy
-msgctxt "help.startTour"
-msgid "Click on the <b>Start Tour</b> globe"
-msgstr "Klicka på globen <b>Starta Tour</b>"
-
-#, fuzzy
-msgctxt "help.startTourAction"
-msgid "button to begin a guided tour of the emulator."
-msgstr "för att börja en guidad rundtur av emulatorn."
-
-#, fuzzy
 msgctxt "help.keyboardShortcuts"
 msgid "Keyboard Shortcuts"
 msgstr "Kortkommandon"

--- a/src/i18n/catalogs/zh-CN.po
+++ b/src/i18n/catalogs/zh-CN.po
@@ -1232,16 +1232,6 @@ msgid "TypeScript Apple IIe Emulator"
 msgstr "TypeScript Apple IIe 模拟器"
 
 #, fuzzy
-msgctxt "help.startTour"
-msgid "Click on the <b>Start Tour</b> globe"
-msgstr "点击 <b>开始导览</b> 地球仪"
-
-#, fuzzy
-msgctxt "help.startTourAction"
-msgid "button to begin a guided tour of the emulator."
-msgstr "按钮开始模拟器的引导式导览。"
-
-#, fuzzy
 msgctxt "help.keyboardShortcuts"
 msgid "Keyboard Shortcuts"
 msgstr "键盘快捷键"

--- a/src/i18n/catalogs/zh-TW.po
+++ b/src/i18n/catalogs/zh-TW.po
@@ -1232,16 +1232,6 @@ msgid "TypeScript Apple IIe Emulator"
 msgstr "TypeScript Apple IIe 模擬器"
 
 #, fuzzy
-msgctxt "help.startTour"
-msgid "Click on the <b>Start Tour</b> globe"
-msgstr "按一下 <b>開始導覽</b> 地球儀"
-
-#, fuzzy
-msgctxt "help.startTourAction"
-msgid "button to begin a guided tour of the emulator."
-msgstr "按鈕開始模擬器的引導式導覽。"
-
-#, fuzzy
 msgctxt "help.keyboardShortcuts"
 msgid "Keyboard Shortcuts"
 msgstr "鍵盤快捷鍵"

--- a/src/i18n/languages/de.ts
+++ b/src/i18n/languages/de.ts
@@ -178,8 +178,6 @@ export const de = {
   "help": {
     "title": "Apple2TS",
     "subtitle": "Apple IIe Emulator in TypeScript",
-    "startTour": "Klicken Sie auf den Globus <b>Tour Starten</b>",
-    "startTourAction": "Taste, um eine geführte Tour des Emulators zu beginnen.",
     "keyboardShortcuts": "Tastaturkürzel",
     "diskImages": "Disk-Images:",
     "urlParameters": "Optionale URL-Parameter",

--- a/src/i18n/languages/en.ts
+++ b/src/i18n/languages/en.ts
@@ -310,8 +310,6 @@ export const en = {
   "help": {
     "title": "Apple2TS",
     "subtitle": "TypeScript Apple IIe Emulator",
-    "startTour": "Click on the <b>Start Tour</b> globe",
-    "startTourAction": "button to begin a guided tour of the emulator.",
     "keyboardShortcuts": "Keyboard Shortcuts",
     "diskImages": "Disk images:",
     "urlParameters": "Optional URL Parameters",

--- a/src/i18n/languages/es.ts
+++ b/src/i18n/languages/es.ts
@@ -178,8 +178,6 @@ export const es = {
   "help": {
     "title": "Apple2TS",
     "subtitle": "Emulador de Apple IIe en TypeScript",
-    "startTour": "Haga clic en el globo <b>Iniciar Recorrido</b>",
-    "startTourAction": "para comenzar una visita guiada por el emulador.",
     "keyboardShortcuts": "Atajos de Teclado",
     "diskImages": "Imágenes de disco:",
     "urlParameters": "Parámetros de URL Opcionales",

--- a/src/i18n/languages/fr.ts
+++ b/src/i18n/languages/fr.ts
@@ -178,8 +178,6 @@ export const fr = {
   "help": {
     "title": "Apple2TS",
     "subtitle": "Émulateur Apple IIe en TypeScript",
-    "startTour": "Cliquez sur le globe <b>Démarrer la visite</b>",
-    "startTourAction": "pour commencer une visite guidata de l'émulateur.",
     "keyboardShortcuts": "Raccourcis Clavier",
     "diskImages": "Images disque :",
     "urlParameters": "Paramètres URL Optionnels",

--- a/src/i18n/languages/it.ts
+++ b/src/i18n/languages/it.ts
@@ -178,8 +178,6 @@ export const it = {
   "help": {
     "title": "Apple2TS",
     "subtitle": "Emulatore Apple IIe in TypeScript",
-    "startTour": "Fai clic sul globo <b>Inizia il Tour</b>",
-    "startTourAction": "per iniziare una visita guidata dell'emulatore.",
     "keyboardShortcuts": "Scorciatoie Tastiera",
     "diskImages": "Immagini disco:",
     "urlParameters": "Parametri URL Opzionali",

--- a/src/i18n/languages/ja.ts
+++ b/src/i18n/languages/ja.ts
@@ -178,8 +178,6 @@ export const ja = {
   "help": {
     "title": "Apple2TS",
     "subtitle": "TypeScript Apple IIe エミュレータ",
-    "startTour": "ツアー開始をクリック",
-    "startTourAction": "ボタンでエミュレータのガイド付きツアーを開始します。",
     "keyboardShortcuts": "キーボードショートカット",
     "diskImages": "ディスクイメージ:",
     "urlParameters": "オプションのURLパラメータ",

--- a/src/i18n/languages/ko.ts
+++ b/src/i18n/languages/ko.ts
@@ -178,8 +178,6 @@ export const ko = {
   "help": {
     "title": "Apple2TS",
     "subtitle": "TypeScript Apple IIe 에뮬레이터",
-    "startTour": "투어 시작 클릭",
-    "startTourAction": "버튼을 눌러 에뮬레이터의 가이드 투어를 시작하세요.",
     "keyboardShortcuts": "키보드 단축키",
     "diskImages": "디스크 이미지:",
     "urlParameters": "선택적 URL 매개변수",

--- a/src/i18n/languages/nl.ts
+++ b/src/i18n/languages/nl.ts
@@ -178,8 +178,6 @@ export const nl = {
   "help": {
     "title": "Apple2TS",
     "subtitle": "TypeScript Apple IIe Emulator",
-    "startTour": "Klik op de globe <b>Tour Starten</b>",
-    "startTourAction": "knop om een rondleiding door de emulator te beginnen.",
     "keyboardShortcuts": "Sneltoetsen",
     "diskImages": "Disk images:",
     "urlParameters": "Optionele URL Parameters",

--- a/src/i18n/languages/pt-BR.ts
+++ b/src/i18n/languages/pt-BR.ts
@@ -178,8 +178,6 @@ export const ptBR = {
   "help": {
     "title": "Apple2TS",
     "subtitle": "Emulador de Apple IIe em TypeScript",
-    "startTour": "Clique no globo <b>Iniciar Tour</b>",
-    "startTourAction": "para iniciar um tour guiado pelo emulador.",
     "keyboardShortcuts": "Atalhos de Teclado",
     "diskImages": "Imagens de disco:",
     "urlParameters": "Parâmetros de URL Opcionais",

--- a/src/i18n/languages/ru.ts
+++ b/src/i18n/languages/ru.ts
@@ -178,8 +178,6 @@ export const ru = {
   "help": {
     "title": "Apple2TS",
     "subtitle": "Эмулятор Apple IIe на TypeScript",
-    "startTour": "Нажмите на глобус <b>Начать экскурсию</b>",
-    "startTourAction": "чтобы начать ознакомительную экскурсию по эмулятору.",
     "keyboardShortcuts": "Горячие клавиши",
     "diskImages": "Образы дисков:",
     "urlParameters": "Опциональные параметры URL",

--- a/src/i18n/languages/sv.ts
+++ b/src/i18n/languages/sv.ts
@@ -178,8 +178,6 @@ export const sv = {
   "help": {
     "title": "Apple2TS",
     "subtitle": "TypeScript Apple IIe Emulator",
-    "startTour": "Klicka på globen <b>Starta Tour</b>",
-    "startTourAction": "för att börja en guidad rundtur av emulatorn.",
     "keyboardShortcuts": "Kortkommandon",
     "diskImages": "Diskavbildningar:",
     "urlParameters": "Valfria URL-parametrar",

--- a/src/i18n/languages/zh-CN.ts
+++ b/src/i18n/languages/zh-CN.ts
@@ -178,8 +178,6 @@ export const zhCN = {
   "help": {
     "title": "Apple2TS",
     "subtitle": "TypeScript Apple IIe 模拟器",
-    "startTour": "点击 <b>开始导览</b> 地球仪",
-    "startTourAction": "按钮开始模拟器的引导式导览。",
     "keyboardShortcuts": "键盘快捷键",
     "diskImages": "磁盘映像文件：",
     "urlParameters": "可选的 URL 参数",

--- a/src/i18n/languages/zh-TW.ts
+++ b/src/i18n/languages/zh-TW.ts
@@ -178,8 +178,6 @@ export const zhTW = {
   "help": {
     "title": "Apple2TS",
     "subtitle": "TypeScript Apple IIe 模擬器",
-    "startTour": "按一下 <b>開始導覽</b> 地球儀",
-    "startTourAction": "按鈕開始模擬器的引導式導覽。",
     "keyboardShortcuts": "鍵盤快捷鍵",
     "diskImages": "磁碟映像檔：",
     "urlParameters": "選用的 URL 參數",


### PR DESCRIPTION
The startup screen stopped directing users to the guided-tour globe before internationalization was added. Two translations for that removed prompt were later introduced without a runtime consumer.

- Remove `help.startTour` and `help.startTourAction` from the translation template and all locale catalogs.
- Regenerate the TypeScript catalogs.
- Leave the active guided-tour implementation and Help renderer unchanged.

This also removes the dead HTML-bearing units from the source Weblate imports.

Tests: `npm test -- --runInBand` — 46 PO-tool tests and 509 Jest tests passed.