### PR TITLE
fix(i18n): prune obsolete PO messages

### DIFF
--- a/src/i18n/README.md
+++ b/src/i18n/README.md
@@ -55,11 +55,12 @@ mutating update command also requires GNU gettext `msgmerge`.
    The updater matches stable `msgctxt` values before invoking `msgmerge`, so a
    rewritten English message retains its existing translation, becomes fuzzy,
    and keeps the previous English wording for comparison. New entries are
-   added, and removed entries become obsolete. It disables cross-key fuzzy
-   matching because the stable `msgctxt`, not similar English wording,
-   identifies a message. Each locale is staged before replacement; a failure
-   preserves the affected original and reports any earlier catalogs already
-   updated.
+   added, and removed entries are deleted rather than retained as obsolete
+   `#~` messages; Git history preserves their earlier translations. It disables
+   cross-key fuzzy matching because the stable `msgctxt`, not similar English
+   wording, identifies a message. Each locale is staged before replacement; a
+   failure preserves the affected original and reports any earlier catalogs
+   already updated.
 3. Review the affected `msgstr` values. Clear fuzzy only after confirming a
    translation against current English. Leave missing translations empty so
    runtime fallback remains visible; do not copy English merely to complete
@@ -67,7 +68,8 @@ mutating update command also requires GNU gettext `msgmerge`.
 4. Run `npm run generate-i18n-catalogs`, then the relevant project checks.
 
 PO files can be edited directly or with standard tools such as Poedit and
-Weblate.
+Weblate. The non-writing catalog check rejects obsolete messages so direct and
+external edits cannot bypass the cleanup policy.
 
 ## Interpolation
 

--- a/tools/i18n/po-catalog.mjs
+++ b/tools/i18n/po-catalog.mjs
@@ -154,9 +154,15 @@ export const preparePoCatalogForMerge = (sourceCatalog, translationCatalog) => {
 
   for (const [context, entries] of Object.entries(translation.translations)) {
     if (!context) continue
+    const sourceItem = sourceMessages.get(context)
+    if (!sourceItem) {
+      delete translation.translations[context]
+      changed = true
+      continue
+    }
+
     for (const [storedMsgid, item] of Object.entries(entries)) {
-      const sourceItem = sourceMessages.get(context)
-      if (!sourceItem || item.msgid === sourceItem.msgid) continue
+      if (item.msgid === sourceItem.msgid) continue
 
       const oldSource = item.msgid
       delete entries[storedMsgid]
@@ -178,6 +184,11 @@ export const preparePoCatalogForMerge = (sourceCatalog, translationCatalog) => {
         setFuzzy(item, false)
       }
     }
+  }
+
+  if (Object.keys(translation.obsolete ?? {}).length > 0) {
+    delete translation.obsolete
+    changed = true
   }
 
   return changed ? poParser.compile(translation).toString() : translationCatalog
@@ -325,6 +336,16 @@ export const compilePoCatalog = (
   const sourceMessages = sourceLanguage
     ? readActiveMessages(source)
     : readActiveMessages(sourceCatalog)
+  const obsolete = (sourceLanguage || requireMerged) && readObsoleteMessages(source)[0]
+  if (obsolete) {
+    const hint = sourceLanguage
+      ? "Remove obsolete messages from the source catalog."
+      : UPDATE_CATALOG_HINT
+    throw new Error(
+      "Catalog contains an obsolete message: "
+      + `${obsolete.key ?? obsolete.source}. ${hint}`,
+    )
+  }
   const sourceTopology = {}
   for (const key of sourceMessages.keys()) {
     setNestedValue(sourceTopology, key, "")

--- a/tools/i18n/po-catalog.test.mjs
+++ b/tools/i18n/po-catalog.test.mjs
@@ -410,6 +410,33 @@ msgstr "Démarrer"
     }])
   })
 
+  it("rejects obsolete entries when a fully merged catalog is required", () => {
+    assert.throws(
+      () => compilePoCatalog(`${english}
+#~ msgctxt "obsolete.message"
+#~ msgid "Old message"
+#~ msgstr "Ancien message"
+`, {requireMerged: true, sourceCatalog: english}),
+      new Error(
+        "Catalog contains an obsolete message: obsolete.message. "
+        + "Update the supplied translation catalog from its source catalog.",
+      ),
+    )
+  })
+
+  it("rejects obsolete entries in the source catalog", () => {
+    assert.throws(
+      () => compilePoCatalog(`${english}
+#~ msgctxt "obsolete.message"
+#~ msgid "Old message"
+`, {sourceLanguage: true}),
+      new Error(
+        "Catalog contains an obsolete message: obsolete.message. "
+        + "Remove obsolete messages from the source catalog.",
+      ),
+    )
+  })
+
   it("validates complete source topology when compiling a partial translation", () => {
     const collidingEnglish = po(`
 msgctxt "controls"

--- a/tools/i18n/update-catalogs.test.mjs
+++ b/tools/i18n/update-catalogs.test.mjs
@@ -112,6 +112,61 @@ msgstr "Enregistrer le disque"
     )
   })
 
+  it("removes messages absent from the source instead of making them obsolete", () => {
+    const directory = mkdtempSync(join(tmpdir(), "apple2ts-po-update-removed-"))
+    temporaryDirectories.push(directory)
+    const source = join(directory, "messages.pot")
+    const input = join(directory, "fr.po")
+    const sourceText = `msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\\n"
+
+msgctxt "disk.save"
+msgid "Save Disk"
+msgstr ""
+`
+    writeFileSync(source, sourceText)
+    writeFileSync(input, `msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\\n"
+
+msgctxt "disk.save"
+msgid "Save Disk"
+msgstr "Enregistrer le disque"
+
+msgctxt "help.removed"
+msgid "Removed help"
+msgstr "Aide supprimée"
+
+#~ msgctxt "help.alreadyObsolete"
+#~ msgid "Already obsolete"
+#~ msgstr "Déjà obsolète"
+`)
+
+    const code = updateCatalogs({
+      catalogDirectory: directory,
+      locales: ["fr"],
+      source,
+      run: () => ({status: 0}),
+    })
+
+    assert.equal(code, 0)
+    const updated = readFileSync(input, "utf8")
+    assert.deepEqual(compilePoCatalog(updated, {sourceCatalog: sourceText}), {
+      disk: {save: "Enregistrer le disque"},
+    })
+    assert.deepEqual(analyzePoCatalog(sourceText, updated).obsolete, [])
+    assert.doesNotMatch(updated, /help\.(?:removed|alreadyObsolete)/)
+
+    assert.equal(updateCatalogs({
+      catalogDirectory: directory,
+      locales: ["fr"],
+      source,
+      run: () => ({status: 0}),
+    }), 0)
+    assert.equal(readFileSync(input, "utf8"), updated)
+  })
+
   it("preserves the original catalog and removes staging after msgmerge fails", () => {
     const directory = mkdtempSync(join(tmpdir(), "apple2ts-po-update-failure-"))
     temporaryDirectories.push(directory)


### PR DESCRIPTION
Removing an English catalog message currently lets `msgmerge` retain its translations as obsolete `#~` entries. Those entries are no longer used by Apple2TS and add noise to catalog reviews.

- Remove translations whose stable `msgctxt` no longer exists in the POT, along with existing obsolete entries.
- Reject obsolete entries in both POT and PO catalogs during the non-writing catalog check.
- Preserve previous-English context for active fuzzy translations when their English wording changes.
- Document the catalog cleanup policy.

This extends the existing atomic catalog preparation step. It adds no command or gettext dependency; contributors continue using `npm run update-i18n-catalogs`.

Tests:

- `npm run test-po-catalog` — 49 tests passed.
- `npm test -- --runInBand` — 509 tests passed.
- `npm run lint`
- `tsc --noEmit`