### PR TITLE
docs(i18n): link Weblate project

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ Refer to the guide above for detailed setup, including environment configuration
 
 ---
 
+## Translations
+
+Help translate Apple2TS online with
+[Weblate](https://hosted.weblate.org/projects/apple2ts/browser-emulator/).
+Developers changing English messages or catalog structure should follow the
+[Apple2TS i18n Developer Guide](src/i18n/README.md).
+
+---
+
 ## Development
 
 Be sure to install `node.js` and `npm` on your system using either `nvm` (the Node version manager) or the Node installer. Either one should work fine.

--- a/src/i18n/README.md
+++ b/src/i18n/README.md
@@ -67,9 +67,12 @@ mutating update command also requires GNU gettext `msgmerge`.
    catalog structure.
 4. Run `npm run generate-i18n-catalogs`, then the relevant project checks.
 
-PO files can be edited directly or with standard tools such as Poedit and
-Weblate. The non-writing catalog check rejects obsolete messages so direct and
-external edits cannot bypass the cleanup policy.
+Translators can use
+[Weblate](https://hosted.weblate.org/projects/apple2ts/browser-emulator/) or
+edit PO files with standard tools such as Poedit. Contributors changing
+English messages or catalog structure should follow the workflow above. The
+non-writing catalog check rejects obsolete messages so direct and external
+edits cannot bypass the cleanup policy.
 
 ## Interpolation
 


### PR DESCRIPTION
Apple2TS has a public Weblate project, but the contributor documentation does not link to it.

- Add a Translations section to the main README.
- Point the i18n developer guide directly to Weblate.
- Keep catalog-maintenance guidance beside the translator entry point.

Verification:

- `git diff --check`
- Weblate link returns HTTP 200.
- Relative i18n guide link resolves in the repository.